### PR TITLE
Fix read_latest_ingest filter

### DIFF
--- a/functions/read.py
+++ b/functions/read.py
@@ -56,7 +56,7 @@ def read_latest_ingest(spark, settings):
     ingest_time_column = settings["ingest_time_column"]
     df = spark.read.table(settings["src_table_name"])
     max_time = df.agg({ingest_time_column: "max"}).collect()[0][0]
-    return df.filter(df["ingest_time"] == max_time)
+    return df.filter(df[ingest_time_column] == max_time)
 
 
 


### PR DESCRIPTION
## Summary
- ensure `read_latest_ingest` uses the configured ingest time column when filtering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68659d21ce008329bb718457886fd5a8