### PR TITLE
Hardcode delta format for stream writes

### DIFF
--- a/functions/write.py
+++ b/functions/write.py
@@ -11,12 +11,11 @@ def stream_write_table(df, settings, spark):
     # Variables
     dst_table_name          = settings.get("dst_table_name")
     writeStreamOptions      = settings.get("writeStreamOptions")
-    writeStream_format      = settings.get("writeStream_format")
 
     # Write
     (
         df.writeStream
-        .format(writeStream_format)
+        .format("delta")
         .options(**writeStreamOptions)
         .outputMode("append")
         .trigger(availableNow=True)

--- a/layer_01_bronze/bodies7days.json
+++ b/layer_01_bronze/bodies7days.json
@@ -16,7 +16,6 @@
         "badRecordsPath": "/Volumes/edsm/bronze/utility/bodies7days/_badRecords/",
         "cloudFiles.rescuedDataColumn": "_rescued_data"
     },
-    "writeStream_format": "delta",
     "writeStreamOptions": {
         "mergeSchema": "false",
         "checkpointLocation": "/Volumes/edsm/bronze/utility/bodies7days/_checkpoints/",

--- a/layer_01_bronze/codex.json
+++ b/layer_01_bronze/codex.json
@@ -16,7 +16,6 @@
         "badRecordsPath": "/Volumes/edsm/bronze/utility/codex/_badRecords/",
         "cloudFiles.rescuedDataColumn": "_rescued_data"
     },
-    "writeStream_format": "delta",
     "writeStreamOptions": {
         "mergeSchema": "false",
         "checkpointLocation": "/Volumes/edsm/bronze/utility/codex/_checkpoints/",

--- a/layer_01_bronze/powerPlay.json
+++ b/layer_01_bronze/powerPlay.json
@@ -16,7 +16,6 @@
         "badRecordsPath": "/Volumes/edsm/bronze/utility/powerPlay/_badRecords/",
         "cloudFiles.rescuedDataColumn": "_rescued_data"
     },
-    "writeStream_format": "delta",
     "writeStreamOptions": {
         "mergeSchema": "false",
         "checkpointLocation": "/Volumes/edsm/bronze/utility/powerPlay/_checkpoints/",

--- a/layer_01_bronze/stations.json
+++ b/layer_01_bronze/stations.json
@@ -16,7 +16,6 @@
         "badRecordsPath": "/Volumes/edsm/bronze/utility/stations/_badRecords/",
         "cloudFiles.rescuedDataColumn": "_rescued_data"
     },
-    "writeStream_format": "delta",
     "writeStreamOptions": {
         "mergeSchema": "false",
         "checkpointLocation": "/Volumes/edsm/bronze/utility/stations/_checkpoints/",

--- a/layer_01_bronze/systemsPopulated.json
+++ b/layer_01_bronze/systemsPopulated.json
@@ -16,7 +16,6 @@
         "badRecordsPath": "/Volumes/edsm/bronze/utility/systemsPopulated/_badRecords/",
         "cloudFiles.rescuedDataColumn": "_rescued_data"
     },
-    "writeStream_format": "delta",
     "writeStreamOptions": {
         "mergeSchema": "false",
         "checkpointLocation": "/Volumes/edsm/bronze/utility/systemsPopulated/_checkpoints/",

--- a/layer_01_bronze/systemsWithCoordinates.json
+++ b/layer_01_bronze/systemsWithCoordinates.json
@@ -17,7 +17,6 @@
         "badRecordsPath": "/Volumes/edsm/bronze/utility/systemsWithCoordinates/_badRecords/",
         "cloudFiles.rescuedDataColumn": "_rescued_data"
     },
-    "writeStream_format": "delta",
     "writeStreamOptions": {
         "mergeSchema": "false",
         "checkpointLocation": "/Volumes/edsm/bronze/utility/systemsWithCoordinates/_checkpoints/",

--- a/layer_01_bronze/systemsWithCoordinates7days.json
+++ b/layer_01_bronze/systemsWithCoordinates7days.json
@@ -16,7 +16,6 @@
         "badRecordsPath": "/Volumes/edsm/bronze/utility/systemsWithCoordinates7days/_badRecords/",
         "cloudFiles.rescuedDataColumn": "_rescued_data"
     },
-    "writeStream_format": "delta",
     "writeStreamOptions": {
         "mergeSchema": "false",
         "checkpointLocation": "/Volumes/edsm/bronze/utility/systemsWithCoordinates7days/_checkpoints/",

--- a/layer_01_bronze/systemsWithoutCoordinates.json
+++ b/layer_01_bronze/systemsWithoutCoordinates.json
@@ -16,7 +16,6 @@
         "badRecordsPath": "/Volumes/edsm/bronze/utility/systemsWithoutCoordinates/_badRecords/",
         "cloudFiles.rescuedDataColumn": "_rescued_data"
     },
-    "writeStream_format": "delta",
     "writeStreamOptions": {
         "mergeSchema": "false",
         "checkpointLocation": "/Volumes/edsm/bronze/utility/systemsWithoutCoordinates/_checkpoints/",


### PR DESCRIPTION
## Summary
- simplify `stream_write_table` by hardcoding `delta` format
- clean up job config JSON files
- fix variable alignment per review feedback

## Testing
- `python -m py_compile functions/write.py`


------
https://chatgpt.com/codex/tasks/task_e_6866af464bdc8329866f45a9dff9229d