### PR TITLE
Remove unused optional function check

### DIFF
--- a/functions/internal/sanity.py
+++ b/functions/internal/sanity.py
@@ -64,11 +64,6 @@ def validate_settings(project_root, dbutils):
         "gold":["read_function","transform_function","write_function","src_table_name","dst_table_name"]
     }
 
-    optional_functions={
-        "bronze": [],
-        "silver": ["upsert_function"],
-        "gold": []
-    }
 
     write_key_requirements = {
         "functions.stream_upsert_table": [
@@ -93,10 +88,6 @@ def validate_settings(project_root, dbutils):
             for k in required_functions[layer]:
                 if k not in settings:
                     errs.append(f"{path} missing {k}")
-            for k in optional_functions[layer]:
-                if k in settings:
-                    print(f"Found optional function in {path}: {k}")
-
             write_fn = settings.get("write_function")
             if write_fn in write_key_requirements:
                 for req_key in write_key_requirements[write_fn]:


### PR DESCRIPTION
## Summary
- clean up `validate_settings` by removing `optional_functions` dict and the associated loop

## Testing
- `python -m py_compile functions/internal/sanity.py`

------
https://chatgpt.com/codex/tasks/task_e_6866f7e517e48329ac2c16662c20c882