### PR TITLE
Move init rebuild logic to separate module

### DIFF
--- a/01_rebuild_init_files.ipynb
+++ b/01_rebuild_init_files.ipynb
@@ -54,7 +54,7 @@
     "    project_root = f\"{os.getcwd()}\"\n",
     "    sys.path.append(project_root)\n",
     "\n",
-    "from functions.internal.sanity import build_all_init\n",
+    "from functions.internal.rebuild_init import build_all_init\n",
     "build_all_init(project_root)"
    ]
   }

--- a/02_sanity_check.ipynb
+++ b/02_sanity_check.ipynb
@@ -20,7 +20,7 @@
    "source": [
     "import os\n",
     "import sys\n",
-    "from functions.internal.sanity import build_all_init, validate_settings, initialize_empty_tables\n",
+    "from functions.internal.sanity import validate_settings, initialize_empty_tables\n",
     "\n",
     "try:\n",
     "    project_root = dbutils.jobs.taskValues.get(taskKey=\"job_settings\", key=\"project_root\", debugValue=None)\n",

--- a/functions/internal/rebuild_init.py
+++ b/functions/internal/rebuild_init.py
@@ -1,0 +1,40 @@
+import os
+import ast
+
+
+def extract_function_names(filepath):
+    with open(filepath, "r", encoding="utf-8") as f:
+        tree = ast.parse(f.read(), filename=filepath)
+    return [node.name for node in tree.body if isinstance(node, ast.FunctionDef)]
+
+
+def generate_init_file(directory):
+    lines = []
+    all_exports = []
+    for filename in sorted(os.listdir(directory)):
+        fullpath = os.path.join(directory, filename)
+        if filename.endswith(".py") and filename != "__init__.py" and os.path.isfile(fullpath):
+            modname = filename[:-3]
+            func_names = extract_function_names(fullpath)
+            if func_names:
+                lines.append(f"from .{modname} import " + ", ".join(func_names))
+                all_exports.extend(func_names)
+    if all_exports:
+        lines.append("")
+        lines.append("__all__ = [" + ", ".join(f'\"{name}\"' for name in all_exports) + "]")
+    init_path = os.path.join(directory, "__init__.py")
+    with open(init_path, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines) + "\n")
+
+
+def build_all_init(project_root):
+    os.chdir(project_root)
+    errs = []
+    for layer in ["functions"]:
+        try:
+            generate_init_file(layer)
+        except Exception as e:
+            errs.append(f"Failed to generate __init__.py for {layer}: {e}")
+    if errs:
+        raise RuntimeError("Errors in build_all_init: " + "; ".join(errs))
+    print("Sanity check: Python __init__.py files rebuild check passed.")

--- a/functions/internal/sanity.py
+++ b/functions/internal/sanity.py
@@ -1,48 +1,8 @@
 import os
-import ast
 import json
-import importlib
 from glob import glob
-from pathlib import Path
 from pyspark.sql.types import StructType
 from functions.utility import create_table_if_not_exists, get_function
-
-## Rebuild __init__.py files before getting started
-def extract_function_names(filepath):
-    with open(filepath, "r", encoding="utf-8") as f:
-        tree = ast.parse(f.read(), filename=filepath)
-    return [node.name for node in tree.body if isinstance(node, ast.FunctionDef)]
-
-def generate_init_file(directory):
-    lines = []
-    all_exports = []
-    for filename in sorted(os.listdir(directory)):
-        fullpath = os.path.join(directory, filename)
-        if filename.endswith(".py") and filename != "__init__.py" and os.path.isfile(fullpath):
-            modname = filename[:-3]
-            func_names = extract_function_names(fullpath)
-            if func_names:
-                lines.append(f"from .{modname} import " + ", ".join(func_names))
-                all_exports.extend(func_names)
-    if all_exports:
-        lines.append("")
-        lines.append("__all__ = [" + ", ".join(f'"{name}"' for name in all_exports) + "]")
-    init_path = os.path.join(directory, "__init__.py")
-    with open(init_path, "w", encoding="utf-8") as f:
-        f.write("\n".join(lines) + "\n")
-
-def build_all_init(project_root):
-    os.chdir(project_root)
-    errs = []
-    for layer in [ "functions" ]:
-        try:
-            generate_init_file(layer)
-        except Exception as e:
-            errs.append(f"Failed to generate __init__.py for {layer}: {e}")
-    if errs:
-        raise RuntimeError("Errors in build_all_init: " + "; ".join(errs))
-    print("Sanity check: Python __init__.py files rebuild check passed.")
-
 
 def validate_settings(project_root, dbutils):
     os.chdir(project_root)


### PR DESCRIPTION
## Summary
- extract `build_all_init` and helpers to `rebuild_init.py`
- update `sanity.py` imports
- update notebooks that import `build_all_init`

## Testing
- `python -m py_compile functions/internal/rebuild_init.py functions/internal/sanity.py`

------
https://chatgpt.com/codex/tasks/task_e_6866f8b027008329af8478955440f281