### PR TITLE
Escape regex backslashes in bronze configs

### DIFF
--- a/layer_01_bronze/bodies7days.json
+++ b/layer_01_bronze/bodies7days.json
@@ -3,7 +3,7 @@
     "transform_function": "functions.bronze_standard_transform",
     "write_function": "functions.stream_write_table",
     "dst_table_name": "edsm.bronze.bodies7days",
-    "derived_ingest_time_regex": "/(\d{8})/",
+    "derived_ingest_time_regex": "/(\\d{8})/",
     "build_history": "true",
     "readStream_load": "/Volumes/edsm/bronze/landing/",
     "readStreamOptions": {

--- a/layer_01_bronze/codex.json
+++ b/layer_01_bronze/codex.json
@@ -3,7 +3,7 @@
     "transform_function": "functions.bronze_standard_transform",
     "write_function": "functions.stream_write_table",
     "dst_table_name": "edsm.bronze.codex",
-    "derived_ingest_time_regex": "/(\d{8})/",
+    "derived_ingest_time_regex": "/(\\d{8})/",
     "build_history": "true",
     "readStream_load": "/Volumes/edsm/bronze/landing/",
     "readStreamOptions": {

--- a/layer_01_bronze/powerPlay.json
+++ b/layer_01_bronze/powerPlay.json
@@ -3,7 +3,7 @@
     "transform_function": "functions.bronze_standard_transform",
     "write_function": "functions.stream_write_table",
     "dst_table_name": "edsm.bronze.powerPlay",
-    "derived_ingest_time_regex": "/(\d{8})/",
+    "derived_ingest_time_regex": "/(\\d{8})/",
     "build_history": "true",
     "readStream_load": "/Volumes/edsm/bronze/landing/",
     "readStreamOptions": {

--- a/layer_01_bronze/stations.json
+++ b/layer_01_bronze/stations.json
@@ -3,7 +3,7 @@
     "transform_function": "functions.bronze_standard_transform",
     "write_function": "functions.stream_write_table",
     "dst_table_name": "edsm.bronze.stations",
-    "derived_ingest_time_regex": "/(\d{8})/",
+    "derived_ingest_time_regex": "/(\\d{8})/",
     "build_history": "true",
     "readStream_load": "/Volumes/edsm/bronze/landing/",
     "readStreamOptions": {

--- a/layer_01_bronze/systemsPopulated.json
+++ b/layer_01_bronze/systemsPopulated.json
@@ -3,7 +3,7 @@
     "transform_function": "functions.bronze_standard_transform",
     "write_function": "functions.stream_write_table",
     "dst_table_name": "edsm.bronze.systemsPopulated",
-    "derived_ingest_time_regex": "/(\d{8})/",
+    "derived_ingest_time_regex": "/(\\d{8})/",
     "build_history": "true",
     "readStream_load": "/Volumes/edsm/bronze/landing/",
     "readStreamOptions": {

--- a/layer_01_bronze/systemsWithCoordinates.json
+++ b/layer_01_bronze/systemsWithCoordinates.json
@@ -3,7 +3,7 @@
     "transform_function": "functions.bronze_standard_transform",
     "write_function": "functions.stream_write_table",
     "dst_table_name": "edsm.bronze.systemsWithCoordinates",
-    "derived_ingest_time_regex": "/(\d{8})/",
+    "derived_ingest_time_regex": "/(\\d{8})/",
     "build_history": "true",
     "readStream_load": "/Volumes/edsm/bronze/landing/",
     "readStreamOptions": {

--- a/layer_01_bronze/systemsWithCoordinates7days.json
+++ b/layer_01_bronze/systemsWithCoordinates7days.json
@@ -3,7 +3,7 @@
     "transform_function": "functions.bronze_standard_transform",
     "write_function": "functions.stream_write_table",
     "dst_table_name": "edsm.bronze.systemsWithCoordinates7days",
-    "derived_ingest_time_regex": "/(\d{8})/",
+    "derived_ingest_time_regex": "/(\\d{8})/",
     "build_history": "true",
     "readStream_load": "/Volumes/edsm/bronze/landing/",
     "readStreamOptions": {

--- a/layer_01_bronze/systemsWithoutCoordinates.json
+++ b/layer_01_bronze/systemsWithoutCoordinates.json
@@ -3,7 +3,7 @@
     "transform_function": "functions.bronze_standard_transform",
     "write_function": "functions.stream_write_table",
     "dst_table_name": "edsm.bronze.systemsWithoutCoordinates",
-    "derived_ingest_time_regex": "/(\d{8})/",
+    "derived_ingest_time_regex": "/(\\d{8})/",
     "build_history": "true",
     "readStream_load": "/Volumes/edsm/bronze/landing/",
     "readStreamOptions": {


### PR DESCRIPTION
## Summary
- fix invalid escape sequences in all bronze layer JSON settings

## Testing
- `pytest -q`
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6866fe6637888329a0eb9a32488f300f