### PR TITLE
Fix module exports

### DIFF
--- a/functions/__init__.py
+++ b/functions/__init__.py
@@ -1,1 +1,22 @@
 
+"""Expose key functions at the package level.
+
+The JSON settings files reference functions using the ``functions.*`` path.
+To make those references work with :func:`importlib.import_module` used in
+``utility.get_function`` we re-export the relevant functions here.  Without
+these imports ``get_function('functions.<name>')`` fails because the
+attribute does not exist on the ``functions`` package.
+"""
+
+from .read import *  # noqa:F401,F403
+from .write import *  # noqa:F401,F403
+from .transform import *  # noqa:F401,F403
+from .history import *  # noqa:F401,F403
+from .utility import *  # noqa:F401,F403
+
+__all__ = [
+    name
+    for name in globals().keys()
+    if not name.startswith("_")
+]
+


### PR DESCRIPTION
## Summary
- expose transform, read, write and other functions at package root

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686708bd34488329871030ff024d0955