### PR TITLE
Add optional derived ingest time

### DIFF
--- a/functions/transform.py
+++ b/functions/transform.py
@@ -32,11 +32,15 @@ import re
 
 def bronze_standard_transform(df, settings, spark):
     derived_ingest_time_regex = settings.get("derived_ingest_time_regex", "/(\\d{8})/")
-    return (
+    add_derived = settings.get("add_derived_ingest_time", "false").lower() == "true"
+    df = (
         df.transform(clean_column_names)
         .transform(add_source_metadata, settings)
         .withColumn("ingest_time", current_timestamp())
-        .withColumn(
+    )
+
+    if add_derived:
+        df = df.withColumn(
             "derived_ingest_time",
             to_timestamp(
                 concat(
@@ -47,7 +51,8 @@ def bronze_standard_transform(df, settings, spark):
                 "yyyyMMdd HH:mm:ss",
             ),
         )
-    )
+
+    return df
 
 def silver_standard_transform(df, settings, spark):
     # Settings

--- a/layer_01_bronze/bodies7days.json
+++ b/layer_01_bronze/bodies7days.json
@@ -4,6 +4,7 @@
     "write_function": "functions.stream_write_table",
     "dst_table_name": "edsm.bronze.bodies7days",
     "derived_ingest_time_regex": "/(\\d{8})/",
+    "add_derived_ingest_time": "true",
     "build_history": "true",
     "readStream_load": "/Volumes/edsm/bronze/landing/",
     "readStreamOptions": {

--- a/layer_01_bronze/codex.json
+++ b/layer_01_bronze/codex.json
@@ -4,6 +4,7 @@
     "write_function": "functions.stream_write_table",
     "dst_table_name": "edsm.bronze.codex",
     "derived_ingest_time_regex": "/(\\d{8})/",
+    "add_derived_ingest_time": "true",
     "build_history": "true",
     "readStream_load": "/Volumes/edsm/bronze/landing/",
     "readStreamOptions": {

--- a/layer_01_bronze/powerPlay.json
+++ b/layer_01_bronze/powerPlay.json
@@ -4,6 +4,7 @@
     "write_function": "functions.stream_write_table",
     "dst_table_name": "edsm.bronze.powerPlay",
     "derived_ingest_time_regex": "/(\\d{8})/",
+    "add_derived_ingest_time": "true",
     "build_history": "true",
     "readStream_load": "/Volumes/edsm/bronze/landing/",
     "readStreamOptions": {

--- a/layer_01_bronze/stations.json
+++ b/layer_01_bronze/stations.json
@@ -4,6 +4,7 @@
     "write_function": "functions.stream_write_table",
     "dst_table_name": "edsm.bronze.stations",
     "derived_ingest_time_regex": "/(\\d{8})/",
+    "add_derived_ingest_time": "true",
     "build_history": "true",
     "readStream_load": "/Volumes/edsm/bronze/landing/",
     "readStreamOptions": {

--- a/layer_01_bronze/systemsPopulated.json
+++ b/layer_01_bronze/systemsPopulated.json
@@ -4,6 +4,7 @@
     "write_function": "functions.stream_write_table",
     "dst_table_name": "edsm.bronze.systemsPopulated",
     "derived_ingest_time_regex": "/(\\d{8})/",
+    "add_derived_ingest_time": "true",
     "build_history": "true",
     "readStream_load": "/Volumes/edsm/bronze/landing/",
     "readStreamOptions": {

--- a/layer_01_bronze/systemsWithCoordinates.json
+++ b/layer_01_bronze/systemsWithCoordinates.json
@@ -4,6 +4,7 @@
     "write_function": "functions.stream_write_table",
     "dst_table_name": "edsm.bronze.systemsWithCoordinates",
     "derived_ingest_time_regex": "/(\\d{8})/",
+    "add_derived_ingest_time": "true",
     "build_history": "true",
     "readStream_load": "/Volumes/edsm/bronze/landing/",
     "readStreamOptions": {

--- a/layer_01_bronze/systemsWithCoordinates7days.json
+++ b/layer_01_bronze/systemsWithCoordinates7days.json
@@ -4,6 +4,7 @@
     "write_function": "functions.stream_write_table",
     "dst_table_name": "edsm.bronze.systemsWithCoordinates7days",
     "derived_ingest_time_regex": "/(\\d{8})/",
+    "add_derived_ingest_time": "true",
     "build_history": "true",
     "readStream_load": "/Volumes/edsm/bronze/landing/",
     "readStreamOptions": {

--- a/layer_01_bronze/systemsWithoutCoordinates.json
+++ b/layer_01_bronze/systemsWithoutCoordinates.json
@@ -4,6 +4,7 @@
     "write_function": "functions.stream_write_table",
     "dst_table_name": "edsm.bronze.systemsWithoutCoordinates",
     "derived_ingest_time_regex": "/(\\d{8})/",
+    "add_derived_ingest_time": "true",
     "build_history": "true",
     "readStream_load": "/Volumes/edsm/bronze/landing/",
     "readStreamOptions": {


### PR DESCRIPTION
## Summary
- gate derived ingest time column behind `add_derived_ingest_time` setting
- enable the setting for all bronze jobs

## Testing
- `PYTHONDONTWRITEBYTECODE=1 python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6867d4465ff08329bf375e48265eea13