### PR TITLE
Add notebook for SCD changes query in powerplay

### DIFF
--- a/sandbox/SQL_powerplay_scd_changes.ipynb
+++ b/sandbox/SQL_powerplay_scd_changes.ipynb
@@ -1,0 +1,102 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {"byteLimit": 2048000, "rowLimit": 10000},
+     "inputWidgets": {},
+     "nuid": "e1c7ad8f-1111-4a5d-8eb9-000000000001",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "SELECT\n",
+    "    MIN(valid_from) AS earliest_valid_from,\n",
+    "    MAX(valid_to) AS latest_valid_to\n",
+    "FROM edsm.silver.v_powerplay"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {"byteLimit": 2048000, "rowLimit": 10000},
+     "inputWidgets": {},
+     "nuid": "e1c7ad8f-1111-4a5d-8eb9-000000000002",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "SELECT\n",
+    "    id,\n",
+    "    power,\n",
+    "    COUNT(DISTINCT struct(allegiance, government, powerState, state)) AS version_count\n",
+    "FROM edsm.silver.v_powerplay\n",
+    "GROUP BY id, power\n",
+    "HAVING version_count > 1\n",
+    "ORDER BY version_count DESC, id, power"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {"byteLimit": 2048000, "rowLimit": 10000},
+     "inputWidgets": {},
+     "nuid": "e1c7ad8f-1111-4a5d-8eb9-000000000003",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "SELECT\n",
+    "    id,\n",
+    "    power,\n",
+    "    allegiance,\n",
+    "    government,\n",
+    "    powerState,\n",
+    "    state,\n",
+    "    valid_from,\n",
+    "    valid_to\n",
+    "FROM edsm.silver.v_powerplay\n",
+    "WHERE (id, power) IN (\n",
+    "    SELECT id, power\n",
+    "    FROM edsm.silver.v_powerplay\n",
+    "    GROUP BY id, power\n",
+    "    HAVING COUNT(DISTINCT struct(allegiance, government, powerState, state)) > 1\n",
+    ")\n",
+    "ORDER BY id, power, valid_from"
+   ]
+  }
+ ],
+ "metadata": {
+  "application/vnd.databricks.v1+notebook": {
+   "computePreferences": null,
+   "dashboards": [],
+   "environmentMetadata": {
+    "base_environment": "",
+    "environment_version": "2"
+   },
+   "inputWidgetPreferences": null,
+   "language": "sql",
+   "notebookMetadata": {"pythonIndentUnit": 4},
+   "notebookName": "SQL_powerplay_scd_changes",
+   "widgets": {}
+  },
+  "language_info": {"name": "sql"}
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
## Summary
- add new SQL notebook to examine surrogate key changes in `silver.powerplay`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867dc6f29488329ab16c5a4e5996d65