### PR TITLE
Add job configuration save utility

### DIFF
--- a/functions/__init__.py
+++ b/functions/__init__.py
@@ -1,4 +1,3 @@
-
 """Expose key functions at the package level.
 
 The JSON settings files reference functions using the ``functions.*`` path.
@@ -15,10 +14,6 @@ from .history import *  # noqa:F401,F403
 from .utility import *  # noqa:F401,F403
 from .rescue import *  # noqa:F401,F403
 from .sanity import *  # noqa:F401,F403
+from .job import *  # noqa:F401,F403
 
-__all__ = [
-    name
-    for name in globals().keys()
-    if not name.startswith("_")
-]
-
+__all__ = [name for name in globals().keys() if not name.startswith("_")]

--- a/functions/job.py
+++ b/functions/job.py
@@ -1,0 +1,38 @@
+import json
+import os
+from pathlib import Path
+
+import requests
+
+
+def save_job_configuration(dbutils, project_root):
+    """Retrieve the current job's configuration as JSON and save it.
+
+    Parameters
+    ----------
+    dbutils : Databricks dbutils
+        Utility object used to fetch context information.
+    project_root : str or Path
+        Root directory of the project. The job JSON is written to
+        ``<project_root>/jobs/<job-name>.json``.
+    """
+    ctx = dbutils.notebook.entry_point.getDbutils().notebook().getContext()
+    job_id = ctx.jobId().getOrElse(None)
+    if job_id is None:
+        raise RuntimeError("Not running inside a job")
+
+    host = os.environ.get("DATABRICKS_HOST") or ctx.apiUrl().get()
+    token = os.environ.get("DATABRICKS_TOKEN") or ctx.apiToken().get()
+
+    url = f"{host}/api/2.1/jobs/get"
+    resp = requests.get(
+        url, headers={"Authorization": f"Bearer {token}"}, params={"job_id": job_id}
+    )
+    resp.raise_for_status()
+
+    job_config = resp.json()
+    job_name = job_config.get("settings", {}).get("name", f"job-{job_id}")
+
+    dst = Path(project_root) / "jobs" / f"{job_name}.json"
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    dst.write_text(json.dumps(job_config, indent=4))


### PR DESCRIPTION
## Summary
- expose job saving utility in `functions` package
- add `save_job_configuration` to write current job JSON to `project_root/jobs/<job-name>.json`

## Testing
- `ruff check functions/job.py functions/__init__.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6867f61372c88329a2f40c9919f5cc94