### PR TITLE
Improve get_function docstring

### DIFF
--- a/functions/utility.py
+++ b/functions/utility.py
@@ -8,6 +8,17 @@ from pyspark.sql.types import StructType
 
 
 def get_function(path):
+    """Return a callable from a dotted module path.
+
+    ``path`` should be a fully qualified object name such as
+    ``"functions.read.stream_read_cloudfiles"``.  The string is split
+    once from the right with ``path.rsplit(".", 1)`` so any dots before
+    the last one become part of the module path and the final segment is
+    the attribute name.  A ``ValueError`` is raised if no ``'.'`` is present.
+    ``ModuleNotFoundError`` or ``AttributeError`` propagate when the
+    module or attribute cannot be imported.
+    """
+
     module_path, func_name = path.rsplit(".", 1)
     module = importlib.import_module(module_path)
     return getattr(module, func_name)


### PR DESCRIPTION
## Summary
- clarify that `get_function` accepts dotted paths with multiple segments
- mention how rsplit handles extra dots in the docstring

## Testing
- `python -m py_compile functions/utility.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68681dda98588329b30b7af55df20af7