### PR TITLE
Update write function references

### DIFF
--- a/dashboards/Python_nearestBySystemState.ipynb
+++ b/dashboards/Python_nearestBySystemState.ipynb
@@ -39,7 +39,7 @@
     "# settings = {\n",
     "#     \"read_function\": \"functions.stream_read_table\",\n",
     "#     \"transform_function\": \"functions.silver_standard_transform\",\n",
-    "#     \"write_function\": \"functions.stream_upsert_table\",\n",
+    "#     \"write_function\": \"functions.write.stream_upsert_table\",\n",
     "#     \"upsert_function\": \"functions.upsert_microbatch\",\n",
     "#     \"src_table_name\": \"edsm.bronze.systemsWithCoordinates\",\n",
     "#     \"dst_table_name\": \"edsm.silver.systemsWithCoordinates\",\n",

--- a/functions/sanity.py
+++ b/functions/sanity.py
@@ -43,17 +43,17 @@ def validate_settings(project_root, dbutils):
 
 
     write_key_requirements = {
-        "functions.stream_upsert_table": [
+        "functions.write.stream_upsert_table": [
             "business_key",
             "surrogate_key",
             "upsert_function",
         ],
-        "functions.batch_upsert_scd2": [
+        "functions.write.batch_upsert_scd2": [
             "business_key",
             "surrogate_key",
             "upsert_function",
         ],
-        "functions.write_upsert_snapshot": ["business_key"],
+        "functions.write.write_upsert_snapshot": ["business_key"],
     }
 
     errs = []

--- a/layer_02_silver/bodies7days.json
+++ b/layer_02_silver/bodies7days.json
@@ -1,7 +1,7 @@
 {
     "read_function": "functions.stream_read_table",
     "transform_function": "functions.silver_scd2_transform",
-    "write_function": "functions.stream_upsert_table",
+    "write_function": "functions.write.stream_upsert_table",
     "upsert_function": "functions.microbatch_upsert_scd2_fn",
     "src_table_name": "edsm.bronze.bodies7days",
     "dst_table_name": "edsm.silver.bodies7days",

--- a/layer_02_silver/powerPlay.json
+++ b/layer_02_silver/powerPlay.json
@@ -1,7 +1,7 @@
 {
     "read_function": "functions.stream_read_table",
     "transform_function": "functions.silver_scd2_transform",
-    "write_function": "functions.stream_upsert_table",
+    "write_function": "functions.write.stream_upsert_table",
     "upsert_function": "functions.microbatch_upsert_scd2_fn",
     "src_table_name": "edsm.bronze.powerPlay",
     "dst_table_name": "edsm.silver.powerPlay",

--- a/layer_02_silver/stations.json
+++ b/layer_02_silver/stations.json
@@ -1,7 +1,7 @@
 {
     "read_function": "functions.stream_read_table",
     "transform_function": "functions.silver_scd2_transform",
-    "write_function": "functions.stream_upsert_table",
+    "write_function": "functions.write.stream_upsert_table",
     "upsert_function": "functions.microbatch_upsert_scd2_fn",
     "src_table_name": "edsm.bronze.stations",
     "dst_table_name": "edsm.silver.stations",

--- a/layer_02_silver/systemsPopulated.json
+++ b/layer_02_silver/systemsPopulated.json
@@ -1,7 +1,7 @@
 {
     "read_function": "functions.stream_read_table",
     "transform_function": "functions.silver_scd2_transform",
-    "write_function": "functions.stream_upsert_table",
+    "write_function": "functions.write.stream_upsert_table",
     "upsert_function": "functions.microbatch_upsert_scd2_fn",
     "src_table_name": "edsm.bronze.systemsPopulated",
     "dst_table_name": "edsm.silver.systemsPopulated",

--- a/layer_02_silver/systemsWithCoordinates7days.json
+++ b/layer_02_silver/systemsWithCoordinates7days.json
@@ -1,7 +1,7 @@
 {
     "read_function": "functions.stream_read_table",
     "transform_function": "functions.silver_standard_transform",
-    "write_function": "functions.stream_upsert_table",
+    "write_function": "functions.write.stream_upsert_table",
     "upsert_function": "functions.microbatch_upsert_fn",
     "src_table_name": "edsm.bronze.systemsWithCoordinates7days",
     "dst_table_name": "edsm.silver.systemsWithCoordinates",


### PR DESCRIPTION
## Summary
- update JSON configs to use `functions.write.stream_upsert_table`
- fix sanity check for new module paths
- adjust example notebook comment for new function path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686820afd7548329aa4cd7e94ac7eee6