### PR TITLE
Fix JSON function module paths

### DIFF
--- a/layer_01_bronze/bodies7days.json
+++ b/layer_01_bronze/bodies7days.json
@@ -1,7 +1,7 @@
 {
-    "read_function": "functions.stream_read_cloudfiles",
-    "transform_function": "functions.bronze_standard_transform",
-    "write_function": "functions.stream_write_table",
+    "read_function": "functions.read.stream_read_cloudfiles",
+    "transform_function": "functions.transform.bronze_standard_transform",
+    "write_function": "functions.write.stream_write_table",
     "dst_table_name": "edsm.bronze.bodies7days",
     "derived_ingest_time_regex": "/(\\d{8})/",
     "add_derived_ingest_time": "true",

--- a/layer_01_bronze/codex.json
+++ b/layer_01_bronze/codex.json
@@ -1,7 +1,7 @@
 {
-    "read_function": "functions.stream_read_cloudfiles",
-    "transform_function": "functions.bronze_standard_transform",
-    "write_function": "functions.stream_write_table",
+    "read_function": "functions.read.stream_read_cloudfiles",
+    "transform_function": "functions.transform.bronze_standard_transform",
+    "write_function": "functions.write.stream_write_table",
     "dst_table_name": "edsm.bronze.codex",
     "derived_ingest_time_regex": "/(\\d{8})/",
     "add_derived_ingest_time": "true",

--- a/layer_01_bronze/powerPlay.json
+++ b/layer_01_bronze/powerPlay.json
@@ -1,7 +1,7 @@
 {
-    "read_function": "functions.stream_read_cloudfiles",
-    "transform_function": "functions.bronze_standard_transform",
-    "write_function": "functions.stream_write_table",
+    "read_function": "functions.read.stream_read_cloudfiles",
+    "transform_function": "functions.transform.bronze_standard_transform",
+    "write_function": "functions.write.stream_write_table",
     "dst_table_name": "edsm.bronze.powerPlay",
     "derived_ingest_time_regex": "/(\\d{8})/",
     "add_derived_ingest_time": "true",

--- a/layer_01_bronze/stations.json
+++ b/layer_01_bronze/stations.json
@@ -1,7 +1,7 @@
 {
-    "read_function": "functions.stream_read_cloudfiles",
-    "transform_function": "functions.bronze_standard_transform",
-    "write_function": "functions.stream_write_table",
+    "read_function": "functions.read.stream_read_cloudfiles",
+    "transform_function": "functions.transform.bronze_standard_transform",
+    "write_function": "functions.write.stream_write_table",
     "dst_table_name": "edsm.bronze.stations",
     "derived_ingest_time_regex": "/(\\d{8})/",
     "add_derived_ingest_time": "true",

--- a/layer_01_bronze/systemsPopulated.json
+++ b/layer_01_bronze/systemsPopulated.json
@@ -1,7 +1,7 @@
 {
-    "read_function": "functions.stream_read_cloudfiles",
-    "transform_function": "functions.bronze_standard_transform",
-    "write_function": "functions.stream_write_table",
+    "read_function": "functions.read.stream_read_cloudfiles",
+    "transform_function": "functions.transform.bronze_standard_transform",
+    "write_function": "functions.write.stream_write_table",
     "dst_table_name": "edsm.bronze.systemsPopulated",
     "derived_ingest_time_regex": "/(\\d{8})/",
     "add_derived_ingest_time": "true",

--- a/layer_01_bronze/systemsWithCoordinates.json
+++ b/layer_01_bronze/systemsWithCoordinates.json
@@ -1,7 +1,7 @@
 {
-    "read_function": "functions.stream_read_cloudfiles",
-    "transform_function": "functions.bronze_standard_transform",
-    "write_function": "functions.stream_write_table",
+    "read_function": "functions.read.stream_read_cloudfiles",
+    "transform_function": "functions.transform.bronze_standard_transform",
+    "write_function": "functions.write.stream_write_table",
     "dst_table_name": "edsm.bronze.systemsWithCoordinates",
     "derived_ingest_time_regex": "/(\\d{8})/",
     "add_derived_ingest_time": "true",

--- a/layer_01_bronze/systemsWithCoordinates7days.json
+++ b/layer_01_bronze/systemsWithCoordinates7days.json
@@ -1,7 +1,7 @@
 {
-    "read_function": "functions.stream_read_cloudfiles",
-    "transform_function": "functions.bronze_standard_transform",
-    "write_function": "functions.stream_write_table",
+    "read_function": "functions.read.stream_read_cloudfiles",
+    "transform_function": "functions.transform.bronze_standard_transform",
+    "write_function": "functions.write.stream_write_table",
     "dst_table_name": "edsm.bronze.systemsWithCoordinates7days",
     "derived_ingest_time_regex": "/(\\d{8})/",
     "add_derived_ingest_time": "true",

--- a/layer_01_bronze/systemsWithoutCoordinates.json
+++ b/layer_01_bronze/systemsWithoutCoordinates.json
@@ -1,7 +1,7 @@
 {
-    "read_function": "functions.stream_read_cloudfiles",
-    "transform_function": "functions.bronze_standard_transform",
-    "write_function": "functions.stream_write_table",
+    "read_function": "functions.read.stream_read_cloudfiles",
+    "transform_function": "functions.transform.bronze_standard_transform",
+    "write_function": "functions.write.stream_write_table",
     "dst_table_name": "edsm.bronze.systemsWithoutCoordinates",
     "derived_ingest_time_regex": "/(\\d{8})/",
     "add_derived_ingest_time": "true",

--- a/layer_02_silver/bodies7days.json
+++ b/layer_02_silver/bodies7days.json
@@ -1,8 +1,8 @@
 {
-    "read_function": "functions.stream_read_table",
-    "transform_function": "functions.silver_scd2_transform",
+    "read_function": "functions.read.stream_read_table",
+    "transform_function": "functions.transform.silver_scd2_transform",
     "write_function": "functions.write.stream_upsert_table",
-    "upsert_function": "functions.microbatch_upsert_scd2_fn",
+    "upsert_function": "functions.write.microbatch_upsert_scd2_fn",
     "src_table_name": "edsm.bronze.bodies7days",
     "dst_table_name": "edsm.silver.bodies7days",
     "build_history": "false",

--- a/layer_02_silver/codex.json
+++ b/layer_02_silver/codex.json
@@ -1,7 +1,7 @@
 {
-    "read_function": "functions.read_table",
-    "transform_function": "functions.silver_standard_transform",
-    "write_function": "functions.overwrite_table",
+    "read_function": "functions.read.read_table",
+    "transform_function": "functions.transform.silver_standard_transform",
+    "write_function": "functions.write.overwrite_table",
     "src_table_name": "edsm.bronze.codex",
     "dst_table_name": "edsm.silver.codex",
     "build_history": "false",

--- a/layer_02_silver/powerPlay.json
+++ b/layer_02_silver/powerPlay.json
@@ -1,8 +1,8 @@
 {
-    "read_function": "functions.stream_read_table",
-    "transform_function": "functions.silver_scd2_transform",
+    "read_function": "functions.read.stream_read_table",
+    "transform_function": "functions.transform.silver_scd2_transform",
     "write_function": "functions.write.stream_upsert_table",
-    "upsert_function": "functions.microbatch_upsert_scd2_fn",
+    "upsert_function": "functions.write.microbatch_upsert_scd2_fn",
     "src_table_name": "edsm.bronze.powerPlay",
     "dst_table_name": "edsm.silver.powerPlay",
     "build_history": "false",

--- a/layer_02_silver/stations.json
+++ b/layer_02_silver/stations.json
@@ -1,8 +1,8 @@
 {
-    "read_function": "functions.stream_read_table",
-    "transform_function": "functions.silver_scd2_transform",
+    "read_function": "functions.read.stream_read_table",
+    "transform_function": "functions.transform.silver_scd2_transform",
     "write_function": "functions.write.stream_upsert_table",
-    "upsert_function": "functions.microbatch_upsert_scd2_fn",
+    "upsert_function": "functions.write.microbatch_upsert_scd2_fn",
     "src_table_name": "edsm.bronze.stations",
     "dst_table_name": "edsm.silver.stations",
     "build_history": "false",

--- a/layer_02_silver/systemsPopulated.json
+++ b/layer_02_silver/systemsPopulated.json
@@ -1,8 +1,8 @@
 {
-    "read_function": "functions.stream_read_table",
-    "transform_function": "functions.silver_scd2_transform",
+    "read_function": "functions.read.stream_read_table",
+    "transform_function": "functions.transform.silver_scd2_transform",
     "write_function": "functions.write.stream_upsert_table",
-    "upsert_function": "functions.microbatch_upsert_scd2_fn",
+    "upsert_function": "functions.write.microbatch_upsert_scd2_fn",
     "src_table_name": "edsm.bronze.systemsPopulated",
     "dst_table_name": "edsm.silver.systemsPopulated",
     "build_history": "false",

--- a/layer_02_silver/systemsWithCoordinates7days.json
+++ b/layer_02_silver/systemsWithCoordinates7days.json
@@ -1,8 +1,8 @@
 {
-    "read_function": "functions.stream_read_table",
-    "transform_function": "functions.silver_standard_transform",
+    "read_function": "functions.read.stream_read_table",
+    "transform_function": "functions.transform.silver_standard_transform",
     "write_function": "functions.write.stream_upsert_table",
-    "upsert_function": "functions.microbatch_upsert_fn",
+    "upsert_function": "functions.write.microbatch_upsert_fn",
     "src_table_name": "edsm.bronze.systemsWithCoordinates7days",
     "dst_table_name": "edsm.silver.systemsWithCoordinates",
     "build_history": "false",

--- a/layer_02_silver/systemsWithoutCoordinates.json
+++ b/layer_02_silver/systemsWithoutCoordinates.json
@@ -1,7 +1,7 @@
 {
-    "read_function": "functions.read_table",
-    "transform_function": "functions.silver_standard_transform",
-    "write_function": "functions.overwrite_table",
+    "read_function": "functions.read.read_table",
+    "transform_function": "functions.transform.silver_standard_transform",
+    "write_function": "functions.write.overwrite_table",
     "src_table_name": "edsm.bronze.systemsWithoutCoordinates",
     "dst_table_name": "edsm.silver.systemsWithoutCoordinates",
     "build_history": "false",


### PR DESCRIPTION
## Summary
- qualify all function references with module paths in `layer_01_bronze` and `layer_02_silver` configs

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6868218f11fc8329a5eaeb99fbeae6c9