### PR TITLE
Stop chdir usage in sanity helpers

### DIFF
--- a/functions/sanity.py
+++ b/functions/sanity.py
@@ -1,30 +1,28 @@
-import os
 import json
-from glob import glob
+from pathlib import Path
 from pyspark.sql.types import StructType
 from functions.utility import create_table_if_not_exists, get_function
 
 
 def _discover_settings_files(project_root):
     """Return dictionaries of settings files for each layer."""
-    os.chdir(project_root)
+    project_root = Path(project_root)
     bronze_files = {
-        f.split("/")[-1].replace(".json", ""): f
-        for f in glob("./layer_*_bronze/*.json")
+        f.stem: str(f)
+        for f in project_root.glob("layer_*_bronze/*.json")
     }
     silver_files = {
-        f.split("/")[-1].replace(".json", ""): f
-        for f in glob("./layer_*_silver/*.json")
+        f.stem: str(f)
+        for f in project_root.glob("layer_*_silver/*.json")
     }
     gold_files = {
-        f.split("/")[-1].replace(".json", ""): f
-        for f in glob("./layer_*_gold/*.json")
+        f.stem: str(f)
+        for f in project_root.glob("layer_*_gold/*.json")
     }
 
     return bronze_files, silver_files, gold_files
 
 def validate_settings(project_root, dbutils):
-    os.chdir(project_root)
     ## Check that all json settings files have the minimum required keys AKA functions before proceeding
     bronze_inputs = dbutils.jobs.taskValues.get(taskKey="job_settings", key="bronze")
     silver_inputs = dbutils.jobs.taskValues.get(taskKey="job_settings", key="silver")


### PR DESCRIPTION
## Summary
- build absolute paths in `_discover_settings_files`
- stop changing cwd in `validate_settings`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6868247754648329a413079cf45c0914