### PR TITLE
Add unified upsert_table helper

### DIFF
--- a/functions/write.py
+++ b/functions/write.py
@@ -36,45 +36,73 @@ def stream_upsert_table(df, settings, spark):
         .start()
     )
 
-def microbatch_upsert_fn(settings, spark):
-    # Variables
-    dst_table_name          = settings.get("dst_table_name")
-    business_key           = settings.get("business_key")
-    surrogate_key            = settings.get("surrogate_key")
 
-    use_row_hash            = settings.get("use_row_hash", False)
-    row_hash_col            = settings.get("row_hash_col", "row_hash")
-    surrogate_key            = settings.get("surrogate_key")
+def _simple_merge(df, settings, spark):
+    """Perform the standard merge logic used for non-SCD2 upserts."""
+    dst_table_name = settings.get("dst_table_name")
+    business_key = settings.get("business_key")
+    surrogate_key = settings.get("surrogate_key")
+
+    use_row_hash = settings.get("use_row_hash", False)
+    row_hash_col = settings.get("row_hash_col", "row_hash")
+
+    merge_condition = " and ".join([f"t.{k} = s.{k}" for k in business_key])
+    if use_row_hash:
+        change_condition = f"t.{row_hash_col} <> s.{row_hash_col}"
+    else:
+        change_condition = " or ".join([f"t.{k} <> s.{k}" for k in surrogate_key])
+
+    df.createOrReplaceTempView("updates")
+    spark.sql(
+        f"""
+        MERGE INTO {dst_table_name} t
+        USING updates s
+        ON {merge_condition}
+        WHEN MATCHED AND ({change_condition}) THEN UPDATE SET *
+        WHEN NOT MATCHED THEN INSERT *
+        """
+    )
+
+
+def upsert_table(df, settings, spark, *, scd2=False, foreach_batch=False, batch_id=None):
+    """Generic helper to upsert ``df`` into the destination table.
+
+    Parameters
+    ----------
+    df : DataFrame
+        Input DataFrame or micro-batch DataFrame when used with ``foreachBatch``.
+    settings : dict
+        Configuration dictionary containing table names and keys.
+    spark : SparkSession
+    scd2 : bool, optional
+        When ``True`` apply SCD2 merge logic. Defaults to ``False``.
+    foreach_batch : bool, optional
+        Set to ``True`` when called inside a ``foreachBatch`` loop so the
+        destination table can be created on the first micro-batch. Defaults to
+        ``False``.
+    batch_id : int, optional
+        Current micro-batch id. Only used when ``foreach_batch`` is ``True``.
+    """
+
+    if foreach_batch and batch_id == 0:
+        create_table_if_not_exists(spark, df, settings.get("dst_table_name"))
+
+    if scd2:
+        _scd2_upsert(df, settings, spark)
+    else:
+        _simple_merge(df, settings, spark)
+
+def microbatch_upsert_fn(settings, spark):
+    """Wrapper used in ``foreachBatch`` for standard upserts."""
 
     def upsert(microBatchDF, batchId):
-        # Sanity check needs to be in its own place
-        if batchId == 0:
-            create_table_if_not_exists(spark, microBatchDF, dst_table_name)
-
-        # from pyspark.sql.functions import row_number
-        # from pyspark.sql.window import Window
-        # if use_row_hash:
-        #     window = Window.partitionBy(*business_key).orderBy(row_hash_col)
-        # else:
-        #     window = Window.partitionBy(*business_key).orderBy(*surrogate_key)
-        # microBatchDF = microBatchDF.withColumn("rn", row_number().over(window)).filter("rn = 1").drop("rn")
-
-        merge_condition = " and ".join([f"t.{k} = s.{k}" for k in business_key])
-        # change_condition = " or ".join([f"t.{k}<>s.{k}" for k in surrogate_key])
-        if use_row_hash:
-            change_condition = f"t.{row_hash_col} <> s.{row_hash_col}"
-        else:
-            change_condition = " or ".join([f"t.{k} <> s.{k}" for k in surrogate_key])
-
-        microBatchDF.createOrReplaceTempView("updates")
-        spark.sql(
-            f"""
-            MERGE INTO {dst_table_name} t
-            USING updates s
-            ON {merge_condition}
-            WHEN MATCHED AND ({change_condition}) THEN UPDATE SET *
-            WHEN NOT MATCHED THEN INSERT *
-            """
+        upsert_table(
+            microBatchDF,
+            settings,
+            spark,
+            scd2=False,
+            foreach_batch=True,
+            batch_id=batchId,
         )
 
     return upsert
@@ -136,16 +164,27 @@ def _scd2_upsert(df, settings, spark):
 
 
 def microbatch_upsert_scd2_fn(settings, spark):
+    """Wrapper used in ``foreachBatch`` for SCD2 style upserts."""
+
     def upsert(microBatchDF, batchId):
         print(f"Starting batchId: {batchId}, count: {microBatchDF.count()}")
         microBatchDF.show(5, truncate=False)
 
-        _scd2_upsert(microBatchDF, settings, spark)
+        upsert_table(
+            microBatchDF,
+            settings,
+            spark,
+            scd2=True,
+            foreach_batch=True,
+            batch_id=batchId,
+        )
 
     return upsert
 
 def batch_upsert_scd2(df, settings, spark):
-    _scd2_upsert(df, settings, spark)
+    """Thin wrapper for SCD2 batch upserts."""
+
+    upsert_table(df, settings, spark, scd2=True, foreach_batch=False)
 
 
 

--- a/layer_02_silver/bodies7days.json
+++ b/layer_02_silver/bodies7days.json
@@ -3,6 +3,8 @@
     "transform_function": "functions.transform.silver_scd2_transform",
     "write_function": "functions.write.stream_upsert_table",
     "upsert_function": "functions.write.microbatch_upsert_scd2_fn",
+    "foreach_batch": true,
+    "scd2": true,
     "src_table_name": "edsm.bronze.bodies7days",
     "dst_table_name": "edsm.silver.bodies7days",
     "build_history": "false",

--- a/layer_02_silver/powerPlay.json
+++ b/layer_02_silver/powerPlay.json
@@ -3,6 +3,8 @@
     "transform_function": "functions.transform.silver_scd2_transform",
     "write_function": "functions.write.stream_upsert_table",
     "upsert_function": "functions.write.microbatch_upsert_scd2_fn",
+    "foreach_batch": true,
+    "scd2": true,
     "src_table_name": "edsm.bronze.powerPlay",
     "dst_table_name": "edsm.silver.powerPlay",
     "build_history": "false",

--- a/layer_02_silver/stations.json
+++ b/layer_02_silver/stations.json
@@ -3,6 +3,8 @@
     "transform_function": "functions.transform.silver_scd2_transform",
     "write_function": "functions.write.stream_upsert_table",
     "upsert_function": "functions.write.microbatch_upsert_scd2_fn",
+    "foreach_batch": true,
+    "scd2": true,
     "src_table_name": "edsm.bronze.stations",
     "dst_table_name": "edsm.silver.stations",
     "build_history": "false",

--- a/layer_02_silver/systemsPopulated.json
+++ b/layer_02_silver/systemsPopulated.json
@@ -3,6 +3,8 @@
     "transform_function": "functions.transform.silver_scd2_transform",
     "write_function": "functions.write.stream_upsert_table",
     "upsert_function": "functions.write.microbatch_upsert_scd2_fn",
+    "foreach_batch": true,
+    "scd2": true,
     "src_table_name": "edsm.bronze.systemsPopulated",
     "dst_table_name": "edsm.silver.systemsPopulated",
     "build_history": "false",

--- a/layer_02_silver/systemsWithCoordinates7days.json
+++ b/layer_02_silver/systemsWithCoordinates7days.json
@@ -3,6 +3,8 @@
     "transform_function": "functions.transform.silver_standard_transform",
     "write_function": "functions.write.stream_upsert_table",
     "upsert_function": "functions.write.microbatch_upsert_fn",
+    "foreach_batch": true,
+    "scd2": false,
     "src_table_name": "edsm.bronze.systemsWithCoordinates7days",
     "dst_table_name": "edsm.silver.systemsWithCoordinates",
     "build_history": "false",


### PR DESCRIPTION
## Summary
- add `upsert_table` helper handling both SCD2 and standard merges
- wrap existing upsert utilities around the new helper
- annotate silver config files with foreach_batch/scd2 flags

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68683c2c82c083299b8600fc9be8dfdc