### PR TITLE
Remove unused keys from silver configs

### DIFF
--- a/layer_02_silver/bodies7days.json
+++ b/layer_02_silver/bodies7days.json
@@ -3,8 +3,6 @@
     "transform_function": "functions.transform.silver_scd2_transform",
     "write_function": "functions.write.stream_upsert_table",
     "upsert_function": "functions.write.microbatch_upsert_scd2_fn",
-    "foreach_batch": true,
-    "scd2": true,
     "src_table_name": "edsm.bronze.bodies7days",
     "dst_table_name": "edsm.silver.bodies7days",
     "build_history": "false",

--- a/layer_02_silver/powerPlay.json
+++ b/layer_02_silver/powerPlay.json
@@ -3,8 +3,6 @@
     "transform_function": "functions.transform.silver_scd2_transform",
     "write_function": "functions.write.stream_upsert_table",
     "upsert_function": "functions.write.microbatch_upsert_scd2_fn",
-    "foreach_batch": true,
-    "scd2": true,
     "src_table_name": "edsm.bronze.powerPlay",
     "dst_table_name": "edsm.silver.powerPlay",
     "build_history": "false",

--- a/layer_02_silver/stations.json
+++ b/layer_02_silver/stations.json
@@ -3,8 +3,6 @@
     "transform_function": "functions.transform.silver_scd2_transform",
     "write_function": "functions.write.stream_upsert_table",
     "upsert_function": "functions.write.microbatch_upsert_scd2_fn",
-    "foreach_batch": true,
-    "scd2": true,
     "src_table_name": "edsm.bronze.stations",
     "dst_table_name": "edsm.silver.stations",
     "build_history": "false",

--- a/layer_02_silver/systemsPopulated.json
+++ b/layer_02_silver/systemsPopulated.json
@@ -3,8 +3,6 @@
     "transform_function": "functions.transform.silver_scd2_transform",
     "write_function": "functions.write.stream_upsert_table",
     "upsert_function": "functions.write.microbatch_upsert_scd2_fn",
-    "foreach_batch": true,
-    "scd2": true,
     "src_table_name": "edsm.bronze.systemsPopulated",
     "dst_table_name": "edsm.silver.systemsPopulated",
     "build_history": "false",

--- a/layer_02_silver/systemsWithCoordinates7days.json
+++ b/layer_02_silver/systemsWithCoordinates7days.json
@@ -3,8 +3,6 @@
     "transform_function": "functions.transform.silver_standard_transform",
     "write_function": "functions.write.stream_upsert_table",
     "upsert_function": "functions.write.microbatch_upsert_fn",
-    "foreach_batch": true,
-    "scd2": false,
     "src_table_name": "edsm.bronze.systemsWithCoordinates7days",
     "dst_table_name": "edsm.silver.systemsWithCoordinates",
     "build_history": "false",


### PR DESCRIPTION
## Summary
- drop unused `foreach_batch` and `scd2` flags from silver config files

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686847b70b4883298f8a31e1e5975f59