### PR TITLE
Enhance streaming defaults for silver and gold

### DIFF
--- a/functions/utility.py
+++ b/functions/utility.py
@@ -96,20 +96,25 @@ def apply_job_type(settings):
                 },
             }
             defaults = _merge_dicts(defaults, dynamic)
-        elif (job_type.startswith("silver") or job_type.startswith("gold")) and "streaming" in job_type:
-            dst = settings.get("dst_table_name")
-            if not dst:
-                raise KeyError("dst_table_name must be provided for streaming job types")
-            catalog, color, table = dst.split(".", 2)
-            base_volume = f"/Volumes/{catalog}/{color}/utility/{table}"
-            dynamic = {
-                "readStreamOptions": {},
-                "writeStreamOptions": {
-                    "mergeSchema": "false",
-                    "checkpointLocation": f"{base_volume}/_checkpoints/",
-                    "delta.columnMapping.mode": "name",
-                },
-            }
+        elif job_type.startswith("silver") or job_type.startswith("gold"):
+            dynamic = {"build_history": "false"}
+
+            if "streaming" in job_type:
+                dst = settings.get("dst_table_name")
+                if not dst:
+                    raise KeyError("dst_table_name must be provided for streaming job types")
+                catalog, color, table = dst.split(".", 2)
+                base_volume = f"/Volumes/{catalog}/{color}/utility/{table}"
+                stream_defaults = {
+                    "readStreamOptions": {},
+                    "writeStreamOptions": {
+                        "mergeSchema": "false",
+                        "checkpointLocation": f"{base_volume}/_checkpoints/",
+                        "delta.columnMapping.mode": "name",
+                    },
+                }
+                dynamic = _merge_dicts(dynamic, stream_defaults)
+
             defaults = _merge_dicts(defaults, dynamic)
 
         settings = _merge_dicts(defaults, settings)

--- a/functions/utility.py
+++ b/functions/utility.py
@@ -96,6 +96,21 @@ def apply_job_type(settings):
                 },
             }
             defaults = _merge_dicts(defaults, dynamic)
+        elif (job_type.startswith("silver") or job_type.startswith("gold")) and "streaming" in job_type:
+            dst = settings.get("dst_table_name")
+            if not dst:
+                raise KeyError("dst_table_name must be provided for streaming job types")
+            catalog, color, table = dst.split(".", 2)
+            base_volume = f"/Volumes/{catalog}/{color}/utility/{table}"
+            dynamic = {
+                "readStreamOptions": {},
+                "writeStreamOptions": {
+                    "mergeSchema": "false",
+                    "checkpointLocation": f"{base_volume}/_checkpoints/",
+                    "delta.columnMapping.mode": "name",
+                },
+            }
+            defaults = _merge_dicts(defaults, dynamic)
 
         settings = _merge_dicts(defaults, settings)
 

--- a/layer_02_silver/bodies7days.json
+++ b/layer_02_silver/bodies7days.json
@@ -3,7 +3,6 @@
     "job_type": "silver_scd2_streaming",
     "src_table_name": "edsm.bronze.bodies7days",
     "dst_table_name": "edsm.silver.bodies7days",
-    "build_history": "false",
     "business_key": [
         "id"
     ],

--- a/layer_02_silver/bodies7days.json
+++ b/layer_02_silver/bodies7days.json
@@ -16,11 +16,5 @@
     "data_type_map": {
         "date": "timestamp"
     },
-    "readStreamOptions": {},
-    "writeStreamOptions": {
-        "mergeSchema": "false",
-        "checkpointLocation": "/Volumes/edsm/silver/utility/bodies7days/_checkpoints/",
-        "delta.columnMapping.mode": "name"
-    },
     "ingest_time_column": "derived_ingest_time"
 }

--- a/layer_02_silver/codex.json
+++ b/layer_02_silver/codex.json
@@ -3,7 +3,6 @@
     "job_type": "silver_standard_batch",
     "src_table_name": "edsm.bronze.codex",
     "dst_table_name": "edsm.silver.codex",
-    "build_history": "false",
     "business_key": [
         "name",
         "region",

--- a/layer_02_silver/powerPlay.json
+++ b/layer_02_silver/powerPlay.json
@@ -17,11 +17,5 @@
     ],
     "data_type_map": {
         "date": "timestamp"
-    },
-    "readStreamOptions": {},
-    "writeStreamOptions": {
-        "mergeSchema": "false",
-        "checkpointLocation": "/Volumes/edsm/silver/utility/powerPlay/_checkpoints/",
-        "delta.columnMapping.mode": "name"
     }
 }

--- a/layer_02_silver/powerPlay.json
+++ b/layer_02_silver/powerPlay.json
@@ -3,7 +3,6 @@
     "job_type": "silver_scd2_streaming",
     "src_table_name": "edsm.bronze.powerPlay",
     "dst_table_name": "edsm.silver.powerPlay",
-    "build_history": "false",
     "ingest_time_column": "derived_ingest_time",
     "business_key": [
         "id",

--- a/layer_02_silver/stations.json
+++ b/layer_02_silver/stations.json
@@ -3,7 +3,6 @@
     "job_type": "silver_scd2_streaming",
     "src_table_name": "edsm.bronze.stations",
     "dst_table_name": "edsm.silver.stations",
-    "build_history": "false",
     "business_key": [
         "id",
         "body",

--- a/layer_02_silver/stations.json
+++ b/layer_02_silver/stations.json
@@ -29,11 +29,5 @@
     "data_type_map": {
         "date": "timestamp"
     },
-    "readStreamOptions": {},
-    "writeStreamOptions": {
-        "mergeSchema": "false",
-        "checkpointLocation": "/Volumes/edsm/silver/utility/stations/_checkpoints/",
-        "delta.columnMapping.mode": "name"
-    },
     "ingest_time_column": "derived_ingest_time"
 }

--- a/layer_02_silver/systemsPopulated.json
+++ b/layer_02_silver/systemsPopulated.json
@@ -3,7 +3,6 @@
     "job_type": "silver_scd2_streaming",
     "src_table_name": "edsm.bronze.systemsPopulated",
     "dst_table_name": "edsm.silver.systemsPopulated",
-    "build_history": "false",
     "business_key": [
         "id"
     ],

--- a/layer_02_silver/systemsPopulated.json
+++ b/layer_02_silver/systemsPopulated.json
@@ -23,11 +23,5 @@
     "data_type_map": {
         "date": "timestamp"
     },
-    "readStreamOptions": {},
-    "writeStreamOptions": {
-        "mergeSchema": "false",
-        "checkpointLocation": "/Volumes/edsm/silver/utility/systemsPopulated/_checkpoints/",
-        "delta.columnMapping.mode": "name"
-    },
     "ingest_time_column": "derived_ingest_time"
 }

--- a/layer_02_silver/systemsWithCoordinates7days.json
+++ b/layer_02_silver/systemsWithCoordinates7days.json
@@ -17,11 +17,5 @@
     "data_type_map": {
         "date": "timestamp"
     },
-    "readStreamOptions": {},
-    "writeStreamOptions": {
-        "mergeSchema": "false",
-        "checkpointLocation": "/Volumes/edsm/silver/utility/systemsWithCoordinates7days/_checkpoints/",
-        "delta.columnMapping.mode": "name"
-    },
     "ingest_time_column": "derived_ingest_time"
 }

--- a/layer_02_silver/systemsWithCoordinates7days.json
+++ b/layer_02_silver/systemsWithCoordinates7days.json
@@ -3,7 +3,6 @@
     "job_type": "silver_standard_streaming",
     "src_table_name": "edsm.bronze.systemsWithCoordinates7days",
     "dst_table_name": "edsm.silver.systemsWithCoordinates",
-    "build_history": "false",
     "business_key": [
         "id"
     ],

--- a/layer_02_silver/systemsWithoutCoordinates.json
+++ b/layer_02_silver/systemsWithoutCoordinates.json
@@ -3,7 +3,6 @@
     "job_type": "silver_standard_batch",
     "src_table_name": "edsm.bronze.systemsWithoutCoordinates",
     "dst_table_name": "edsm.silver.systemsWithoutCoordinates",
-    "build_history": "false",
     "use_row_hash": "true",
     "row_hash_col": "row_hash",
     "business_key": [


### PR DESCRIPTION
## Summary
- add default read/write stream options when dynamically generating silver and gold settings

## Testing
- `python -m py_compile functions/utility.py`


------
https://chatgpt.com/codex/tasks/task_e_6869043d385c83298d998a666e46adc1