### PR TITLE
Change silver standard batch default write

### DIFF
--- a/functions/utility.py
+++ b/functions/utility.py
@@ -34,7 +34,7 @@ JOB_TYPE_MAP = {
     "silver_standard_batch": {
         "read_function": "functions.read.read_table",
         "transform_function": "functions.transform.silver_standard_transform",
-        "write_function": "functions.write.overwrite_table",
+        "write_function": "functions.write.write_upsert_snapshot",
     },
 }
 


### PR DESCRIPTION
## Summary
- use snapshot upsert for silver simple batch jobs

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6869175aa2b083298fe7ee41e58ad3ef