### PR TITLE
Remove dbutils parameter in bad records helper

### DIFF
--- a/03_ingest.ipynb
+++ b/03_ingest.ipynb
@@ -54,7 +54,7 @@
     "else:\n",
     "    raise Exception(f\"Could not find any ingest function name in settings.\")\n",
     "if color == \"bronze\":\n",
-    "    create_bad_records_table(spark, settings, dbutils)\n"
+  "    create_bad_records_table(spark, settings)\n"
    ]
   }
  ],

--- a/functions/utility.py
+++ b/functions/utility.py
@@ -198,7 +198,7 @@ def inspect_checkpoint_folder(settings, table_name, spark):
         print(f"  Silver Batch {batch_id} → Bronze version {version - 1}")
 
 
-def create_bad_records_table(spark, settings, dbutils):
+def create_bad_records_table(spark, settings):
     """Create a delta table from the JSON files located in ``badRecordsPath``.
 
     If the path does not exist, any existing table ``<dst_table_name>_bad_records``


### PR DESCRIPTION
## Summary
- adjust `create_bad_records_table` signature so it no longer accepts `dbutils`
- update `03_ingest.ipynb` call to match new signature

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68693edd5de88329b6ca2f7306bcd7b4