### PR TITLE
Make surrogate key optional

### DIFF
--- a/functions/transform.py
+++ b/functions/transform.py
@@ -60,11 +60,11 @@ def silver_standard_transform(df, settings, spark):
     """Apply common silver layer cleaning logic."""
 
     # Settings
-    surrogate_key            = settings["surrogate_key"]
-    column_map              = settings.get("column_map", None)
-    data_type_map           = settings.get("data_type_map", None)
-    use_row_hash            = str(settings.get("use_row_hash", "false")).lower() == "true"
-    row_hash_col            = settings.get("row_hash_col", "row_hash")
+    surrogate_key = settings.get("surrogate_key", [])
+    column_map = settings.get("column_map", None)
+    data_type_map = settings.get("data_type_map", None)
+    use_row_hash = str(settings.get("use_row_hash", "false")).lower() == "true" and len(surrogate_key) > 0
+    row_hash_col = settings.get("row_hash_col", "row_hash")
 
     return (
         df.transform(rename_columns, column_map)


### PR DESCRIPTION
## Summary
- allow `silver_standard_transform` to work without a `surrogate_key`

## Testing
- `python -m py_compile functions/transform.py`


------
https://chatgpt.com/codex/tasks/task_e_6869420ca8f083298616bb695e6b8030