### PR TITLE
Normalize argument order

### DIFF
--- a/functions/read.py
+++ b/functions/read.py
@@ -4,7 +4,7 @@ from pyspark.sql.types import StructType
 from pyspark.sql.functions import col, row_number
 from pyspark.sql.window import Window
 
-def stream_read_cloudfiles(spark, settings):
+def stream_read_cloudfiles(settings, spark):
     """Read streaming data from a cloudFiles source.
 
     Parameters
@@ -39,7 +39,7 @@ def stream_read_cloudfiles(spark, settings):
     )
 
 
-def stream_read_table(spark, settings):
+def stream_read_table(settings, spark):
     """Create a streaming DataFrame from an existing Delta table."""
 
     # Variables (json file)
@@ -53,12 +53,12 @@ def stream_read_table(spark, settings):
     )
 
 
-def read_table(spark, settings):
+def read_table(settings, spark):
     """Read a Delta table in batch mode."""
     return spark.read.table(settings["src_table_name"])
 
 
-def read_snapshot_windowed(spark, settings):
+def read_snapshot_windowed(settings, spark):
     """Return the most recent record for each key based on an ingest column."""
 
     surrogate_key           = settings["surrogate_key"]
@@ -73,7 +73,7 @@ def read_snapshot_windowed(spark, settings):
     )
 
 
-def read_latest_ingest(spark, settings):
+def read_latest_ingest(settings, spark):
     """Load only the records from the latest ingest time."""
     ingest_time_column = settings["ingest_time_column"]
     df = spark.read.table(settings["src_table_name"])

--- a/functions/sanity.py
+++ b/functions/sanity.py
@@ -123,7 +123,7 @@ def initialize_empty_tables(project_root, spark):
                 break
             df=transform_function(df, settings, spark)
             dst=settings["dst_table_name"]
-            if create_table_if_not_exists(spark, df, dst):
+            if create_table_if_not_exists(df, dst, spark):
                 print(f"\tINFO: Table did not exist and was created: {dst}.")
         if skip_table:
             continue

--- a/functions/utility.py
+++ b/functions/utility.py
@@ -144,7 +144,7 @@ def get_function(path):
     return getattr(module, func_name)
 
 
-def create_table_if_not_exists(spark, df, dst_table_name):
+def create_table_if_not_exists(df, dst_table_name, spark):
     """Create a table from a dataframe if it doesn't exist"""
     if not spark.catalog.tableExists(dst_table_name):
         empty_df = spark.createDataFrame([], df.schema)
@@ -153,18 +153,18 @@ def create_table_if_not_exists(spark, df, dst_table_name):
     return False
 
 
-def create_schema_if_not_exists(spark, catalog, schema):
+def create_schema_if_not_exists(catalog, schema, spark):
     """Create the schema if it is missing."""
     spark.sql(f"CREATE SCHEMA IF NOT EXISTS {catalog}.{schema}")
 
 
-def schema_exists(spark, catalog, schema):
+def schema_exists(catalog, schema, spark):
     """Return True if the schema exists in the given catalog"""
     df = spark.sql(f"SHOW SCHEMAS IN {catalog} LIKE '{schema}'")
     return df.count() > 0
 
 
-def create_volume_if_not_exists(spark, catalog, schema, volume):
+def create_volume_if_not_exists(catalog, schema, volume, spark):
     """Create an external volume pointing to the expected S3 path."""
 
     s3_path = f"s3://edsm/volumes/{catalog}/{schema}/{volume}"
@@ -173,13 +173,13 @@ def create_volume_if_not_exists(spark, catalog, schema, volume):
     )
 
 
-def truncate_table_if_exists(spark, table_name):
+def truncate_table_if_exists(table_name, spark):
     """Truncate ``table_name`` if it already exists."""
 
     if spark.catalog.tableExists(table_name):
         spark.sql(f"TRUNCATE TABLE {table_name}")
 
-def inspect_checkpoint_folder(settings, table_name, spark):
+def inspect_checkpoint_folder(table_name, settings, spark):
     """Print batch to version mapping from a Delta checkpoint folder."""
 
     checkpoint_path = settings.get("writeStreamOptions", {}).get("checkpointLocation")
@@ -198,7 +198,7 @@ def inspect_checkpoint_folder(settings, table_name, spark):
         print(f"  Silver Batch {batch_id} → Bronze version {version - 1}")
 
 
-def create_bad_records_table(spark, settings):
+def create_bad_records_table(settings, spark):
     """Create a delta table from the JSON files located in ``badRecordsPath``.
 
     If the path does not exist, any existing table ``<dst_table_name>_bad_records``

--- a/functions/write.py
+++ b/functions/write.py
@@ -91,7 +91,7 @@ def upsert_table(df, settings, spark, *, scd2=False, foreach_batch=False, batch_
     """
 
     if foreach_batch and batch_id == 0:
-        create_table_if_not_exists(spark, df, settings.get("dst_table_name"))
+        create_table_if_not_exists(df, settings.get("dst_table_name"), spark)
 
     if scd2:
         _scd2_upsert(df, settings, spark)


### PR DESCRIPTION
## Summary
- move Spark session argument to the end of helper functions
- ensure settings argument is second when another parameter exists

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686953fd0c9083299f6c1c2cc3b8b438