### PR TITLE
Add ingest script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# EDSM Delta Pipeline
+
+This repository ingests [EDSM](https://www.edsm.net) dumps into Delta tables.  
+The notebooks in this project were originally used to run each step, but the
+same logic can be executed from a regular Python script.
+
+## Ingesting a table
+
+Use `scripts/ingest.py` to run the read/transform/write pipeline for a single
+settings file.  The script expects the layer colour and table name so it can
+locate `layer_*_<color>/<table>.json`.
+
+```bash
+spark-submit scripts/ingest.py --color bronze --table stations
+```
+
+The script loads the JSON settings, applies `apply_job_type` to expand any
+`simple_settings` values and then runs the pipeline defined by the functions
+listed in the file. If the colour is `bronze` the script will also check for bad
+records using `create_bad_records_table`.
+
+## Migrating from the Notebook
+
+Running `scripts/ingest.py` replaces executing the `03_ingest.ipynb` notebook.
+Any workflow that previously passed widget values to the notebook can instead
+supply the `--color` and `--table` arguments to the script.

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Run the ingestion pipeline using a settings file."""
+
+import argparse
+import json
+from pathlib import Path
+
+from pyspark.sql import SparkSession
+
+from functions.utility import get_function, create_bad_records_table, apply_job_type
+
+
+def load_settings(color: str, table: str) -> dict:
+    pattern = f"./layer_*_{color}/{table}.json"
+    path = next(Path().glob(pattern), None)
+    if path is None:
+        raise FileNotFoundError(f"No settings file matching {pattern}")
+    with open(path) as f:
+        settings = json.load(f)
+    return apply_job_type(settings)
+
+
+def run_pipeline(spark: SparkSession, color: str, table: str) -> None:
+    settings = load_settings(color, table)
+
+    if "pipeline_function" in settings:
+        pipeline_fn = get_function(settings["pipeline_function"])
+        pipeline_fn(spark, settings)
+    elif all(k in settings for k in ["read_function", "transform_function", "write_function"]):
+        read_fn = get_function(settings["read_function"])
+        transform_fn = get_function(settings["transform_function"])
+        write_fn = get_function(settings["write_function"])
+
+        df = read_fn(settings, spark)
+        df = transform_fn(df, settings, spark)
+        write_fn(df, settings, spark)
+    else:
+        raise Exception("Could not find any ingest function name in settings.")
+
+    if color == "bronze":
+        create_bad_records_table(settings, spark)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Ingest table using project settings")
+    parser.add_argument("--color", required=True, help="Layer color (bronze, silver, gold)")
+    parser.add_argument("--table", required=True, help="Table name to ingest")
+    args = parser.parse_args(argv)
+
+    spark = SparkSession.builder.getOrCreate()
+    run_pipeline(spark, args.color, args.table)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add standalone `ingest.py` script for running read/transform/write pipeline
- document how to invoke the new script instead of the old notebook

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686960f25f9c8329a52d4c1c42ffe2d1