### PR TITLE
Add project root printout

### DIFF
--- a/00_job_settings.ipynb
+++ b/00_job_settings.ipynb
@@ -32,7 +32,7 @@
     "job_settings = {}\n",
     "for color in [ \"bronze\", \"silver\", \"gold\" ]:\n",
     "    paths = glob(f'./layer_*_{color}/*.json')\n",
-    "    job_settings[color] = [{\"table\": path.split('/')[-1].split('.')[0]} for path in paths]\n",
+    "    job_settings[color] = [\n        {\"table\": path.split(\"/\")[-1].split(\".\")[0], \"project_root\": project_root}\n        for path in paths]\n",
     "for key, value in job_settings.items():\n",
     "    dbutils.jobs.taskValues.set(key=key, value=value)\n",
     "\n",

--- a/README.md
+++ b/README.md
@@ -8,16 +8,23 @@ same logic can be executed from a regular Python script.
 
 Use `scripts/ingest.py` to run the read/transform/write pipeline for a single
 settings file.  The script expects the layer colour and table name so it can
-locate `layer_*_<color>/<table>.json`.
+locate `layer_*_<color>/<table>.json`.  By default the file is searched for in
+the current working directory, but a different project root can be specified
+with `--project_root`.
 
 ```bash
-spark-submit scripts/ingest.py --color bronze --table stations
+spark-submit scripts/ingest.py \
+    --color bronze \
+    --table {{input.table}} \
+    --project_root {{input.project_root}}
 ```
 
 The script loads the JSON settings, applies `apply_job_type` to expand any
 `simple_settings` values and then runs the pipeline defined by the functions
-listed in the file. If the colour is `bronze` the script will also check for bad
-records using `create_bad_records_table`.
+listed in the file. Before running the functions the script will print the job
+settings dictionary and the contents of the table's JSON file so that the
+configuration is visible. If the colour is `bronze` the script will also check
+for bad records using `create_bad_records_table`.
 
 ## Migrating from the Notebook
 


### PR DESCRIPTION
## Summary
- print job_settings dictionary and table JSON in ingest script
- document the printed configuration details in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68696b2751e88329bc2260aa19d00e09