### PR TITLE
Fix package build configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,5 +17,5 @@ dependencies = [
 edsm-ingest = "scripts.ingest:main"
 
 [tool.setuptools.packages.find]
-include = ["functions"]
+include = ["functions", "scripts"]
 

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,3 @@
+"""Helper package exposing CLI entry points."""
+
+__all__ = []


### PR DESCRIPTION
## Summary
- include `scripts` in the setuptools package search so the console script works
- add an empty `scripts/__init__.py` so the folder is packaged

## Testing
- `pip install build` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68697fde75c483299a1f2f81a4812ee8