### PR TITLE
Add CLI ingest script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,28 @@ path = PROJECT_ROOT / "layer_01_bronze" / "codex.json"
 `PROJECT_ROOT` resolves to the directory containing the installed `edsm`
 package, allowing scripts and notebooks to load bundled files regardless of the
 current working directory.
+
+## Running an ingest job
+
+The `03_ingest.ipynb` notebook can be replaced by the `scripts.ingest` module
+which executes the same pipeline from the command line. Provide the layer
+color and table name as named arguments so the script can locate the appropriate settings file:
+
+```bash
+python -m scripts.ingest --color bronze --table codex
+```
+
+This command loads `layer_*_bronze/codex.json` from the installed package and
+runs the read/transform/write pipeline defined there.
+
+## Running as a wheel in Databricks
+
+When configuring a Databricks job to execute the built wheel, provide the
+following details:
+
+* **Package to import:** `edsm`
+* **Function to call:** `scripts.ingest:main`
+
+The entry point `scripts.ingest:main` is declared in `pyproject.toml` under
+`[project.scripts]` so Databricks can invoke the ingest pipeline after
+installing the wheel.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,6 @@ description = "EDSM data ingestion utilities"
 [tool.setuptools]
 packages = ["functions", "scripts"]
 include-package-data = true
+
+[project.scripts]
+edsm-ingest = "scripts.ingest:main"

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -1,0 +1,60 @@
+import argparse
+import json
+from functions.utility import (
+    get_function,
+    create_bad_records_table,
+    apply_job_type,
+)
+from functions.project_root import PROJECT_ROOT
+from pyspark.sql import SparkSession
+
+
+def _load_settings(color: str, table: str) -> dict:
+    pattern = f"layer_*_{color}/{table}.json"
+    matches = list(PROJECT_ROOT.glob(pattern))
+    if not matches:
+        raise FileNotFoundError(f"No settings file matching {pattern}")
+    path = matches[0]
+    with open(path, "r", encoding="utf-8") as fh:
+        settings = json.load(fh)
+    return apply_job_type(settings)
+
+
+def _run_pipeline(settings: dict, spark: SparkSession, color: str) -> None:
+    if "pipeline_function" in settings:
+        pipeline_function = get_function(settings["pipeline_function"])
+        pipeline_function(settings, spark)
+    elif all(k in settings for k in ["read_function", "transform_function", "write_function"]):
+        read_function = get_function(settings["read_function"])
+        transform_function = get_function(settings["transform_function"])
+        write_function = get_function(settings["write_function"])
+
+        df = read_function(settings, spark)
+        df = transform_function(df, settings, spark)
+        write_function(df, settings, spark)
+    else:
+        raise Exception("Could not find any ingest function name in settings.")
+
+    if color == "bronze":
+        create_bad_records_table(settings, spark)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Execute a table ingest pipeline")
+    parser.add_argument(
+        "--color",
+        required=True,
+        help="Dataset layer color, e.g. bronze or silver",
+    )
+    parser.add_argument(
+        "--table", required=True, help="Table name defined by the settings file"
+    )
+    args = parser.parse_args()
+
+    spark = SparkSession.builder.getOrCreate()
+    settings = _load_settings(args.color, args.table)
+    _run_pipeline(settings, spark, args.color)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `scripts/ingest.py` for running the ingest pipeline from the command line
- document using the new script instead of the notebook
- use `--color` and `--table` named arguments for the CLI script
- explain the package name and entry point used when configuring a Databricks wheel

## Testing
- `python -m py_compile scripts/ingest.py`
- `python -m build` *(fails: No module named build)*

------
https://chatgpt.com/codex/tasks/task_e_6869af41ee588329bc4844fd0bdec446