### PR TITLE
Fix Delta streaming options

### DIFF
--- a/functions/read.py
+++ b/functions/read.py
@@ -48,6 +48,7 @@ def stream_read_table(settings, spark):
 
     return (
         spark.readStream
+        .format("delta")
         .options(**readStreamOptions)
         .table(src_table_name)
     )


### PR DESCRIPTION
## Summary
- ensure Delta-specific options like `startingVersion` are honored by specifying `format("delta")` in `stream_read_table`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest')*

------
https://chatgpt.com/codex/tasks/task_e_686a8265a9dc8329b06bf354d1f34ea2