### PR TITLE
Add back add_rescued_data transform

### DIFF
--- a/functions/transform.py
+++ b/functions/transform.py
@@ -38,8 +38,14 @@ def bronze_standard_transform(df, settings, spark):
     df = (
         df.transform(clean_column_names)
         .transform(add_source_metadata, settings)
-        .withColumn("ingest_time", current_timestamp())
     )
+
+    file_schema = settings.get("file_schema", [])
+    rescue_in_schema = any(
+        isinstance(f, dict) and f.get("name") == "_rescued_data" for f in file_schema
+    )
+
+    df = df.withColumn("ingest_time", current_timestamp())
 
     if add_derived:
         df = df.withColumn(
@@ -53,6 +59,9 @@ def bronze_standard_transform(df, settings, spark):
                 "yyyyMMdd HH:mm:ss",
             ),
         )
+
+    if not rescue_in_schema:
+        df = df.transform(add_rescued_data)
 
     return df
 
@@ -112,6 +121,17 @@ def add_source_metadata(df, settings):
         return df.withColumn("source_metadata", expr("_metadata"))
     else:
         return df.withColumn("source_metadata", lit(None).cast(metadata_type))
+
+
+def add_rescued_data(df):
+    """Ensure a ``_rescued_data`` column exists in the DataFrame."""
+
+    rescued_data_type = StringType()
+
+    if "_rescued_data" in df.columns:
+        return df
+    else:
+        return df.withColumn("_rescued_data", lit(None).cast(rescued_data_type))
 
 
 def make_null_safe(col_expr, dtype):

--- a/tests/test_bronze_transform.py
+++ b/tests/test_bronze_transform.py
@@ -1,0 +1,76 @@
+import sys
+import types
+import pathlib
+from unittest import mock
+import importlib.util
+import unittest
+
+# Create minimal fake pyspark modules before importing transform
+pyspark = types.ModuleType('pyspark')
+sql = types.ModuleType('pyspark.sql')
+types_mod = types.ModuleType('pyspark.sql.types')
+func_mod = types.ModuleType('pyspark.sql.functions')
+sql.types = types_mod
+sql.functions = func_mod
+pyspark.sql = sql
+sys.modules['pyspark'] = pyspark
+sys.modules['pyspark.sql'] = sql
+sys.modules['pyspark.sql.types'] = types_mod
+sys.modules['pyspark.sql.functions'] = func_mod
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+# Provide dummy classes/functions referenced in transform
+for name in [
+    'StructType', 'StructField', 'StringType', 'LongType',
+    'TimestampType', 'ArrayType', 'MapType'
+]:
+    setattr(types_mod, name, type(name, (), {}))
+
+def dummy(*args, **kwargs):
+    return None
+for name in [
+    'concat','regexp_extract','date_format','current_timestamp','when','col',
+    'to_timestamp','to_date','regexp_replace','sha2','lit','trim','struct',
+    'to_json','expr','transform','array'
+]:
+    setattr(func_mod, name, dummy)
+
+# Import the module under test after faking pyspark
+transform_path = pathlib.Path(__file__).resolve().parents[1] / 'functions' / 'transform.py'
+spec = importlib.util.spec_from_file_location('functions.transform', transform_path)
+transform = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(transform)
+
+class DummyDF:
+    def __init__(self, columns=None):
+        self.columns = columns or []
+        self.calls = []
+
+    def transform(self, func, *args, **kwargs):
+        self.calls.append(func.__name__)
+        return self
+
+    def withColumn(self, *args, **kwargs):
+        self.calls.append('withColumn')
+        return self
+
+class BronzeTransformTests(unittest.TestCase):
+    def test_skip_add_rescued_when_schema_contains_column(self):
+        df = DummyDF(['foo'])
+        settings = {
+            'file_schema': [
+                {'name': 'foo', 'type': 'string'},
+                {'name': '_rescued_data', 'type': 'string'}
+            ],
+            'use_metadata': 'true'
+        }
+        with mock.patch.object(transform, 'clean_column_names', new=lambda df_in: df_in), \
+             mock.patch.object(transform, 'add_source_metadata', new=lambda df_in, settings: df_in), \
+             mock.patch.object(transform, 'add_rescued_data', new=mock.Mock(side_effect=lambda df_in: df_in)) as add_mock:
+            transform.bronze_standard_transform(df, settings, spark=None)
+            add_mock.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- restore the `add_rescued_data` function and call it conditionally
- don't run the transform when `_rescued_data` is already in the file schema
- run the rescued data transform after other columns so `_rescued_data` is appended at the end
- add a unit test for this behavior

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c1f42613083299b7805216f890d4b