### PR TITLE
Add silver_upsert_streaming job type

### DIFF
--- a/functions/utility.py
+++ b/functions/utility.py
@@ -20,11 +20,16 @@ JOB_TYPE_MAP = {
         "write_function": "functions.write.stream_upsert_table",
         "upsert_function": "functions.write.microbatch_upsert_scd2_fn",
     },
-    "silver_standard_streaming": {
+    "silver_upsert_streaming": {
         "read_function": "functions.read.stream_read_table",
         "transform_function": "functions.transform.silver_standard_transform",
         "write_function": "functions.write.stream_upsert_table",
         "upsert_function": "functions.write.microbatch_upsert_fn",
+    },
+    "silver_standard_streaming": {
+        "read_function": "functions.read.stream_read_table",
+        "transform_function": "functions.transform.silver_standard_transform",
+        "write_function": "functions.write.stream_write_table",
     },
     "silver_scd2_batch": {
         "read_function": "functions.read.read_table",

--- a/layer_02_silver/systemsWithCoordinates7days.json
+++ b/layer_02_silver/systemsWithCoordinates7days.json
@@ -1,6 +1,6 @@
 {
     "simple_settings": "true",
-    "job_type": "silver_standard_streaming",
+    "job_type": "silver_upsert_streaming",
     "src_table_name": "edsm.bronze.systemsWithCoordinates7days",
     "dst_table_name": "edsm.silver.systemsWithCoordinates",
     "business_key": [


### PR DESCRIPTION
## Summary
- rename the `silver_standard_streaming` job type to `silver_upsert_streaming`
- add a new `silver_standard_streaming` job type using `stream_write_table`
- update sample settings to use the renamed job type

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c2e045cd083298f751ca683afde35