### PR TITLE
Add databricks DQX helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,10 @@
 This repository contains notebooks and utilities for ingesting data from the Elite Dangerous Star Map (EDSM).
 
 For documentation, see [here](https://github.com/bryanlharris/Documentation).
+
+## Data Quality Checks
+
+The `functions.quality` module provides an optional helper to run
+Databricks [DQX](https://pypi.org/project/databricks-labs-dqx/) checks
+as part of a pipeline.  Use `apply_dqx_checks(df, settings, spark)` to
+validate a DataFrame using checks defined inline in the job settings.

--- a/functions/__init__.py
+++ b/functions/__init__.py
@@ -16,6 +16,7 @@ from . import (
     rescue,
     sanity,
     project_root,
+    quality,
 )
 
 __all__ = [
@@ -27,4 +28,5 @@ __all__ = [
     "rescue",
     "sanity",
     "project_root",
+    "quality",
 ]

--- a/functions/quality.py
+++ b/functions/quality.py
@@ -1,0 +1,59 @@
+"""Utilities for integrating Databricks DQX checks.
+
+This module exposes a helper function :func:`apply_dqx_checks` which
+runs data quality checks using the `databricks-labs-dqx` library.  The
+function is written so that importing this module does not require
+``pyspark`` or ``databricks-labs-dqx``.  Dependencies are loaded only
+when the helper is executed.
+"""
+from __future__ import annotations
+
+from typing import Tuple, Any
+
+
+def apply_dqx_checks(df: Any, settings: dict, spark: Any) -> Tuple[Any, Any]:
+    """Apply DQX quality rules to ``df``.
+
+    Parameters
+    ----------
+    df : pyspark.sql.DataFrame
+        Input dataframe to validate.
+    settings : dict
+        Dictionary with optional key ``dqx_checks`` containing a list of
+        check dictionaries in DQX format.
+    spark : pyspark.sql.SparkSession
+        Active spark session used to create empty dataframes when no
+        checks are provided.
+
+    Returns
+    -------
+    Tuple[DataFrame, DataFrame]
+        ``(good_df, bad_df)`` after applying the rules.  When no checks
+        are supplied the original dataframe is returned together with an
+        empty dataframe having the same schema.
+    """
+
+    checks = settings.get("dqx_checks")
+
+    if not checks:
+        # Nothing to do - return df unchanged and empty dataframe
+        return df, spark.createDataFrame([], df.schema)
+
+    # Import heavy dependencies lazily
+    from databricks.labs.dqx.engine import DQEngineCore
+
+    class _DummyCurrentUser:
+        def me(self):
+            return {}
+
+    class _DummyConfig:
+        _product_info = ("dqx", "0.0")
+
+    class _DummyWS:
+        def __init__(self):
+            self.current_user = _DummyCurrentUser()
+            self.config = _DummyConfig()
+
+    dq_engine = DQEngineCore(_DummyWS(), spark)
+    good_df, bad_df = dq_engine.apply_checks_by_metadata_and_split(df, checks)
+    return good_df, bad_df

--- a/layer_02_silver/powerPlay.json
+++ b/layer_02_silver/powerPlay.json
@@ -16,5 +16,128 @@
     ],
     "data_type_map": {
         "date": "timestamp"
-    }
+    },
+    "dqx_checks": [
+        {
+            "name": "id_not_null",
+            "check": {
+                "function": "is_not_null",
+                "arguments": {"column": "id"}
+            }
+        },
+        {
+            "name": "allegiance_enum",
+            "check": {
+                "function": "is_not_null_and_is_in_list",
+                "arguments": {
+                    "column": "allegiance",
+                    "allowed": [
+                        "Pilots Federation",
+                        "Federation",
+                        "Alliance",
+                        "Empire",
+                        "Independent"
+                    ]
+                }
+            }
+        },
+        {
+            "name": "government_enum",
+            "check": {
+                "function": "is_not_null_and_is_in_list",
+                "arguments": {
+                    "column": "government",
+                    "allowed": [
+                        "Theocracy",
+                        "Confederacy",
+                        "Democracy",
+                        "Dictatorship",
+                        "Prison colony",
+                        "Corporate",
+                        "Cooperative",
+                        "Communism",
+                        "Anarchy",
+                        "Patronage",
+                        "Feudal"
+                    ]
+                }
+            }
+        },
+        {
+            "name": "power_enum",
+            "check": {
+                "function": "is_not_null_and_is_in_list",
+                "arguments": {
+                    "column": "power",
+                    "allowed": [
+                        "Felicia Winters",
+                        "A. Lavigny-Duval",
+                        "Pranav Antal",
+                        "Yuri Grom",
+                        "Aisling Duval",
+                        "Archon Delaine",
+                        "Li Yong-Rui",
+                        "Edmund Mahon",
+                        "Nakato Kaine",
+                        "Denton Patreus",
+                        "Zemina Torval",
+                        "Jerome Archer"
+                    ]
+                }
+            }
+        },
+        {
+            "name": "powerState_enum",
+            "check": {
+                "function": "is_not_null_and_is_in_list",
+                "arguments": {
+                    "column": "powerState",
+                    "allowed": [
+                        "Unoccupied",
+                        "Exploited",
+                        "Controlled",
+                        "Fortified",
+                        "Turmoil",
+                        "Contested",
+                        "Stronghold",
+                        "Preparing",
+                        "InPreparation",
+                        "HomeSystem"
+                    ]
+                }
+            }
+        },
+        {
+            "name": "state_enum",
+            "check": {
+                "function": "is_not_null_and_is_in_list",
+                "arguments": {
+                    "column": "state",
+                    "allowed": [
+                        "Boom",
+                        "Retreat",
+                        "Natural Disaster",
+                        "None",
+                        "Infrastructure Failure",
+                        "Blight",
+                        "Outbreak",
+                        "Lockdown",
+                        "Public Holiday",
+                        "Drought",
+                        "Terrorist Attack",
+                        "Civil liberty",
+                        "Famine",
+                        "Civil unrest",
+                        "War",
+                        "Expansion",
+                        "Bust",
+                        "Pirate attack",
+                        "Civil war",
+                        "Investment",
+                        "Election"
+                    ]
+                }
+            }
+        }
+    ]
 }

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1,0 +1,39 @@
+import sys
+import types
+import pathlib
+import importlib.util
+import unittest
+
+# Insert repo root into path
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+# Import quality module dynamically
+quality_path = pathlib.Path(__file__).resolve().parents[1] / 'functions' / 'quality.py'
+spec = importlib.util.spec_from_file_location('functions.quality', quality_path)
+quality = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(quality)
+
+class DummyDF:
+    def __init__(self, schema=None):
+        self.schema = schema
+
+class DummySpark:
+    def __init__(self):
+        self.created = []
+    def createDataFrame(self, data, schema):
+        df = DummyDF(schema)
+        self.created.append((data, schema))
+        return df
+
+class QualityTests(unittest.TestCase):
+    def test_returns_input_when_no_checks(self):
+        df = DummyDF(schema='schema')
+        spark = DummySpark()
+        good, bad = quality.apply_dqx_checks(df, {}, spark)
+        self.assertIs(good, df)
+        self.assertEqual(bad.schema, 'schema')
+        self.assertEqual(len(spark.created), 1)
+        self.assertEqual(spark.created[0][0], [])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `functions.quality` module with helper to run databricks DQX checks
- expose new module in `functions.__init__`
- document DQX usage in `README`
- test new helper
- remove YAML option, rely on settings dict
- add basic checks for powerplay silver table
- expand DQX checks for powerplay enumerations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d805ac74c8329a73a79ee06012e1f