### PR TITLE
Fix DQX helper usage in ingest notebook

### DIFF
--- a/03_ingest.ipynb
+++ b/03_ingest.ipynb
@@ -43,7 +43,7 @@
      "from pathlib import Path\n",
      "from functions.utility import get_function, create_bad_records_table, apply_job_type, schema_exists, print_settings\n",
      "from functions.history import build_and_merge_file_history, transaction_history\n",
-     "from functions.quality import apply_dqx_checks, count_records\n",
+     "from functions.quality import create_dqx_bad_records_table\n
      "import os\n",
     "\n",
     "# Variables\n",
@@ -70,16 +70,8 @@
     "\n",
     "    df = read_function(settings, spark)\n",
     "    df = transform_function(df, settings, spark)\n",
-    "    df, bad_df = apply_dqx_checks(df, settings, spark)\n",
-    "    checkpoint_location = settings['writeStreamOptions']['checkpointLocation']\n",
-    "    if checkpoint_location is not None:\n",
-    "        base = checkpoint_location.rstrip('/')\n",
-    "        parent = os.path.dirname(base)\n",
-    "        checkpoint_location = f\"{parent}/_dqx_checkpoints/\"\n",
-    "    n_bad = count_records(bad_df, spark, checkpoint_location=checkpoint_location)\n",
-    "    if n_bad > 0:\n",
-    "        raise Exception(f\"DQX checks failed: {n_bad} failing records\")\n",
-    "    write_function(df, settings, spark)\n",
+    "    df = create_dqx_bad_records_table(df, settings, spark)\n"
+    "    write_function(df, settings, spark)\n"
     "else:\n",
     "    raise Exception(f'Could not find any ingest function name in settings.')\n",
     "\n",


### PR DESCRIPTION
## Summary
- keep ingest notebook multi-line JSON
- call `create_dqx_bad_records_table` in ingest flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686da923c3a083298fd65406647f538a