### PR TITLE
Handle streaming bad record writes

### DIFF
--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -53,12 +53,21 @@ class DummyWriteStream:
     def start(self):
         self.spark.storage[self.name] = getattr(self.df, "rows", [])
         return DummyStreamingQuery()
+    def table(self, table_name):
+        self.spark.tables.setdefault(table_name, []).extend(
+            getattr(self.df, "rows", [])
+        )
+        return DummyStreamingQuery()
 
 class DummySpark:
     def __init__(self):
         self.created = []
         self.storage = {}
-        self.catalog = types.SimpleNamespace(dropTempView=self.storage.pop)
+        self.tables = {}
+        self.catalog = types.SimpleNamespace(
+            dropTempView=self.storage.pop,
+            tableExists=lambda name: name in self.tables,
+        )
     def createDataFrame(self, data, schema):
         df = DummyDF(schema)
         self.created.append((data, schema))
@@ -107,7 +116,36 @@ class QualityTests(unittest.TestCase):
                 df.writeStream.opts.get('checkpointLocation'),
                 '/tmp/_dqx_checkpoints/abcd/'
             )
-            mock_rm.assert_called_with('/tmp/_dqx_checkpoints/abcd/', ignore_errors=True)
+        mock_rm.assert_called_with('/tmp/_dqx_checkpoints/abcd/', ignore_errors=True)
+
+    def test_create_dqx_bad_records_table_streaming(self):
+        spark = DummySpark()
+        df = DummyDF(schema='schema')
+        bad = DummyStreamingDF([1], spark)
+
+        settings = {
+            'dst_table_name': 'foo',
+            'writeStreamOptions': {'checkpointLocation': '/tmp/base/_checkpoints/'}
+        }
+
+        spark.catalog.tableExists = lambda name: False
+
+        with unittest.mock.patch.object(quality, 'apply_dqx_checks', return_value=(df, bad)), \
+             unittest.mock.patch.object(quality.uuid, 'uuid4') as mock_uuid, \
+             unittest.mock.patch.object(quality, 'count_records', return_value=1), \
+             unittest.mock.patch.object(quality.shutil, 'rmtree') as mock_rm:
+            mock_uuid.return_value.hex = 'abcd'
+            result = quality.create_dqx_bad_records_table(df, settings, spark)
+            self.assertIs(result, df)
+            self.assertEqual(
+                bad.writeStream.opts.get('checkpointLocation'),
+                '/tmp/base/_dqx_checkpoints/abcd/'
+            )
+            self.assertEqual(
+                spark.tables.get('foo_dqx_bad_records'),
+                [1]
+            )
+            mock_rm.assert_called_with('/tmp/base/_dqx_checkpoints/abcd/', ignore_errors=True)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- fix create_dqx_bad_records_table to write streaming bad records directly to Delta
- update streaming bad record test to expect table writes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686db184bd348329aeb4e99bf156f7bb