### PR TITLE
Allow null powerPlay enums

### DIFF
--- a/layer_02_silver/powerPlay.json
+++ b/layer_02_silver/powerPlay.json
@@ -28,7 +28,7 @@
         {
             "name": "allegiance_enum",
             "check": {
-                "function": "is_not_null_and_is_in_list",
+                "function": "is_in_list",
                 "arguments": {
                     "column": "allegiance",
                     "allowed": [
@@ -44,7 +44,7 @@
         {
             "name": "government_enum",
             "check": {
-                "function": "is_not_null_and_is_in_list",
+                "function": "is_in_list",
                 "arguments": {
                     "column": "government",
                     "allowed": [
@@ -66,7 +66,7 @@
         {
             "name": "power_enum",
             "check": {
-                "function": "is_not_null_and_is_in_list",
+                "function": "is_in_list",
                 "arguments": {
                     "column": "power",
                     "allowed": [
@@ -89,7 +89,7 @@
         {
             "name": "powerState_enum",
             "check": {
-                "function": "is_not_null_and_is_in_list",
+                "function": "is_in_list",
                 "arguments": {
                     "column": "powerState",
                     "allowed": [
@@ -110,7 +110,7 @@
         {
             "name": "state_enum",
             "check": {
-                "function": "is_not_null_and_is_in_list",
+                "function": "is_in_list",
                 "arguments": {
                     "column": "state",
                     "allowed": [


### PR DESCRIPTION
## Summary
- relax `powerPlay` enums to allow null values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686db577416083299bdba8ca5215f007