### PR TITLE
Add missing pattern_match rule for DQX

### DIFF
--- a/functions/dq_checks.py
+++ b/functions/dq_checks.py
@@ -48,6 +48,12 @@ def matches_regex_list(df, column, patterns):
     return df.filter(~condition).count() == 0
 
 
+def pattern_match(df, column, pattern):
+    """Return ``True`` if ``column`` matches ``pattern``."""
+
+    return matches_regex_list(df, column, [pattern])
+
+
 def is_nonzero(df, column):
     """Return ``True`` if ``column`` is not zero."""
 

--- a/functions/quality.py
+++ b/functions/quality.py
@@ -18,6 +18,7 @@ from .dq_checks import (
     is_not_null_or_empty,
     max_length,
     matches_regex_list,
+    pattern_match,
     is_nonzero,
     starts_with_prefixes,
 )
@@ -65,6 +66,7 @@ def apply_dqx_checks(df: Any, settings: dict, spark: Any) -> Tuple[Any, Any]:
         "is_not_null_or_empty": is_not_null_or_empty,
         "max_length": max_length,
         "matches_regex_list": matches_regex_list,
+        "pattern_match": pattern_match,
         "is_nonzero": is_nonzero,
         "starts_with_prefixes": starts_with_prefixes,
     }

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -141,6 +141,7 @@ class QualityTests(unittest.TestCase):
         self.assertIn('is_not_null_or_empty', DummyRegistry.registered)
         self.assertIn('max_length', DummyRegistry.registered)
         self.assertIn('matches_regex_list', DummyRegistry.registered)
+        self.assertIn('pattern_match', DummyRegistry.registered)
         self.assertIn('is_nonzero', DummyRegistry.registered)
         self.assertIn('starts_with_prefixes', DummyRegistry.registered)
     def test_count_records_batch(self):


### PR DESCRIPTION
## Summary
- support a `pattern_match` check by adding the function to `dq_checks`
- register new rule in the DQX helper
- test registration of the new rule

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686efbf62ed4832984e39ff3d34f500e