### PR TITLE
Add missing pattern_match function

### DIFF
--- a/functions/dq_checks.py
+++ b/functions/dq_checks.py
@@ -86,6 +86,12 @@ def matches_regex_list(column, patterns):
     )
 
 
+def pattern_match(column, pattern):
+    """Return a column validating ``column`` matches ``pattern``."""
+
+    return matches_regex_list(column, [pattern])
+
+
 def is_nonzero(column):
     """Return a column validating ``column`` is not zero."""
 


### PR DESCRIPTION
## Summary
- restore the `pattern_match` DQX helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f051d87f08329bcb4af8144ebcf13