### PR TITLE
Allow root with or without trailing slash

### DIFF
--- a/functions/utility.py
+++ b/functions/utility.py
@@ -204,6 +204,7 @@ def create_volume_if_not_exists(catalog, schema, volume, spark):
     """Create an external volume pointing to the expected S3 path."""
 
     root = S3_ROOT_LANDING if volume == "landing" else S3_ROOT_UTILITY
+    root = root.rstrip("/") + "/"
     s3_path = f"{root}{catalog}/{schema}/{volume}"
     spark.sql(
         f"CREATE EXTERNAL VOLUME IF NOT EXISTS {catalog}.{schema}.{volume} LOCATION '{s3_path}'"

--- a/tests/test_volume_creation.py
+++ b/tests/test_volume_creation.py
@@ -24,3 +24,12 @@ def test_create_utility_volume_uses_utility_root():
     assert spark.queries[-1] == (
         f"CREATE EXTERNAL VOLUME IF NOT EXISTS cat.sch.utility LOCATION '{config.S3_ROOT_UTILITY}cat/sch/utility'"
     )
+
+def test_volume_root_without_trailing_slash(monkeypatch):
+    spark = DummySpark()
+    root_no_slash = config.S3_ROOT_LANDING.rstrip('/')
+    monkeypatch.setattr(config, 'S3_ROOT_LANDING', root_no_slash)
+    utility.create_volume_if_not_exists('cat', 'sch', 'landing', spark)
+    assert spark.queries[-1] == (
+        f"CREATE EXTERNAL VOLUME IF NOT EXISTS cat.sch.landing LOCATION '{root_no_slash}/cat/sch/landing'"
+    )


### PR DESCRIPTION
## Summary
- allow `create_volume_if_not_exists` to handle root paths that may or may not end with a slash
- add regression test for root without slash

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f164dc640832989facb52b01a11e0