### PR TITLE
Add hostname sanity check

### DIFF
--- a/00_job_settings.ipynb
+++ b/00_job_settings.ipynb
@@ -20,7 +20,7 @@
    "source": [
     "import json\n",
     "from glob import glob\n",
-    "from functions.sanity import validate_settings, initialize_schemas_and_volumes, initialize_empty_tables\n",
+    "from functions.sanity import validate_settings, initialize_schemas_and_volumes, initialize_empty_tables, check_host_name_matches_catalog\n",
     "from functions.utility import apply_job_type\n",
     "\n",
     "# Load anything in layer_*_<color>/*.json\n",
@@ -43,6 +43,7 @@
     "    dbutils.jobs.taskValues.set(key=key, value=value)\n",
     "\n",
     "# Sanity check\n",
+    "check_host_name_matches_catalog(dbutils)\n",
     "validate_settings(dbutils)\n",
     "initialize_schemas_and_volumes(spark)\n",
     "initialize_empty_tables(spark)"

--- a/00_job_settings.ipynb
+++ b/00_job_settings.ipynb
@@ -43,11 +43,11 @@
     "    dbutils.jobs.taskValues.set(key=key, value=value)\n",
     "\n",
     "# Sanity check\n",
-    "check_host_name_matches_catalog(dbutils)\n",
     "validate_settings(dbutils)\n",
     "initialize_schemas_and_volumes(spark)\n",
-    "initialize_empty_tables(spark)"
-  ]
+    "initialize_empty_tables(spark)\n",
+    "check_host_name_matches_catalog(dbutils)\n"
+   ]
   }
  ],
  "metadata": {

--- a/functions/config.py
+++ b/functions/config.py
@@ -43,3 +43,6 @@ JOB_TYPE_MAP = {
 S3_ROOT_LANDING = "s3://edsm/landing/"
 S3_ROOT_UTILITY = "s3://edsm/utility/"
 
+# Allowed Databricks workspace host names
+ALLOWED_HOST_NAMES = {"dbc-bde2b6e3-4903", "dev", "staging", "prod"}
+

--- a/tests/test_check_catalog_match.py
+++ b/tests/test_check_catalog_match.py
@@ -1,0 +1,64 @@
+import sys
+import pathlib
+import types
+import importlib.util
+import json
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+pkg_path = pathlib.Path(__file__).resolve().parents[1] / 'functions'
+functions_pkg = types.ModuleType('functions')
+functions_pkg.__path__ = [str(pkg_path)]
+sys.modules.setdefault('functions', functions_pkg)
+
+# Load modules dynamically
+for name in ['sanity', 'config']:
+    path = pkg_path / f'{name}.py'
+    spec = importlib.util.spec_from_file_location(f'functions.{name}', path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    setattr(functions_pkg, name, mod)
+
+sanity = functions_pkg.sanity
+config = functions_pkg.config
+
+def make_settings(tmp_path, catalog):
+    d = tmp_path / 'layer_01_bronze'
+    d.mkdir()
+    path = d / 'tbl.json'
+    data = {
+        'dst_table_name': f'{catalog}.bronze.tbl',
+        'read_function': 'f',
+        'transform_function': 'f',
+        'write_function': 'f',
+        'file_schema': []
+    }
+    with open(path, 'w') as f:
+        json.dump(data, f)
+    return tmp_path
+
+
+def test_catalog_matches(monkeypatch, tmp_path):
+    root = make_settings(tmp_path, 'dev')
+    monkeypatch.setattr(config, 'PROJECT_ROOT', root)
+    monkeypatch.setattr(sanity, 'PROJECT_ROOT', root)
+    monkeypatch.setenv('DATABRICKS_HOST', 'https://dev.cloud.databricks.com')
+    sanity.check_host_name_matches_catalog()
+
+
+def test_catalog_mismatch(monkeypatch, tmp_path):
+    root = make_settings(tmp_path, 'prod')
+    monkeypatch.setattr(config, 'PROJECT_ROOT', root)
+    monkeypatch.setattr(sanity, 'PROJECT_ROOT', root)
+    monkeypatch.setenv('DATABRICKS_HOST', 'https://dev.cloud.databricks.com')
+    with pytest.raises(RuntimeError):
+        sanity.check_host_name_matches_catalog()
+
+
+def test_exempt_host(monkeypatch, tmp_path):
+    root = make_settings(tmp_path, 'foo')
+    monkeypatch.setattr(config, 'PROJECT_ROOT', root)
+    monkeypatch.setattr(sanity, 'PROJECT_ROOT', root)
+    monkeypatch.setenv('DATABRICKS_HOST', 'https://dbc-bde2b6e3-4903.cloud.databricks.com')
+    sanity.check_host_name_matches_catalog()


### PR DESCRIPTION
## Summary
- check allowed host names from config
- ensure dst_table_name catalog matches host environment
- fail job settings when mismatch occurs
- add tests for new catalog check

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68724110cc3c8329a25b16e83c530da1