### PR TITLE
Move catalog check into settings validation

### DIFF
--- a/00_job_settings.ipynb
+++ b/00_job_settings.ipynb
@@ -20,7 +20,7 @@
    "source": [
     "import json\n",
     "from glob import glob\n",
-    "from functions.sanity import validate_settings, initialize_schemas_and_volumes, initialize_empty_tables, check_host_name_matches_catalog\n",
+    "from functions.sanity import validate_settings, initialize_schemas_and_volumes, initialize_empty_tables\n",
     "from functions.utility import apply_job_type\n",
     "\n",
     "# Load anything in layer_*_<color>/*.json\n",
@@ -44,7 +44,6 @@
     "\n",
     "# Sanity check\n",
     "validate_settings(dbutils)\n",
-    "check_host_name_matches_catalog(dbutils)\n",
     "initialize_schemas_and_volumes(spark)\n",
     "initialize_empty_tables(spark)\n"
    ]

--- a/functions/sanity.py
+++ b/functions/sanity.py
@@ -85,6 +85,9 @@ def validate_settings(dbutils):
     else:
         print("Sanity check: Validate settings check passed.")
 
+    # Ensure the destination catalogs match the current host name
+    check_host_name_matches_catalog(dbutils)
+
 
 def initialize_empty_tables(spark):
     """Create empty Delta tables based on settings definitions."""


### PR DESCRIPTION
## Summary
- validate destination catalogs while validating settings
- adjust notebook to use updated sanity flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872450d73dc8329a030824454dcb953