### PR TITLE
Add gold sampling configs

### DIFF
--- a/functions/transform.py
+++ b/functions/transform.py
@@ -26,6 +26,7 @@ from pyspark.sql.functions import (
     expr,
     transform,
     array,
+    rand,
 )
 import re
 
@@ -263,6 +264,23 @@ def cast_data_types(df, data_type_map=None):
             selected_columns.append(col(column_name))
 
     return df.select(selected_columns)
+
+
+def gold_sample_transform(df, settings, spark):
+    """Return a random sample of ``df`` based on ``sample_fraction``.
+
+    Parameters
+    ----------
+    df : DataFrame
+        Input DataFrame.
+    settings : dict
+        Configuration dictionary that may include ``sample_fraction``.
+    spark : SparkSession
+        Unused but included for API consistency.
+    """
+
+    fraction = float(settings.get("sample_fraction", 0.01))
+    return df.where(rand() < fraction)
 
 
 

--- a/layer_03_gold/bodies7days.json
+++ b/layer_03_gold/bodies7days.json
@@ -1,0 +1,12 @@
+{
+    "simple_settings": "true",
+    "job_type": "silver_standard_batch",
+    "src_table_name": "edsm.silver.bodies7days",
+    "dst_table_name": "edsm.gold.bodies7days",
+    "business_key": [
+        "id"
+    ],
+    "ingest_time_column": "derived_ingest_time",
+    "transform_function": "functions.transform.gold_sample_transform",
+    "sample_fraction": 0.01
+}

--- a/layer_03_gold/codex.json
+++ b/layer_03_gold/codex.json
@@ -1,0 +1,17 @@
+{
+    "simple_settings": "true",
+    "job_type": "silver_standard_batch",
+    "src_table_name": "edsm.silver.codex",
+    "dst_table_name": "edsm.gold.codex",
+    "business_key": [
+        "name",
+        "region",
+        "systemId",
+        "systemId64",
+        "systemName",
+        "type"
+    ],
+    "ingest_time_column": "derived_ingest_time",
+    "transform_function": "functions.transform.gold_sample_transform",
+    "sample_fraction": 0.01
+}

--- a/layer_03_gold/powerPlay.json
+++ b/layer_03_gold/powerPlay.json
@@ -1,0 +1,13 @@
+{
+    "simple_settings": "true",
+    "job_type": "silver_standard_batch",
+    "src_table_name": "edsm.silver.powerPlay",
+    "dst_table_name": "edsm.gold.powerPlay",
+    "business_key": [
+        "id",
+        "power"
+    ],
+    "ingest_time_column": "derived_ingest_time",
+    "transform_function": "functions.transform.gold_sample_transform",
+    "sample_fraction": 0.01
+}

--- a/layer_03_gold/stations.json
+++ b/layer_03_gold/stations.json
@@ -1,0 +1,14 @@
+{
+    "simple_settings": "true",
+    "job_type": "silver_standard_batch",
+    "src_table_name": "edsm.silver.stations",
+    "dst_table_name": "edsm.gold.stations",
+    "business_key": [
+        "id",
+        "body",
+        "systemId"
+    ],
+    "ingest_time_column": "derived_ingest_time",
+    "transform_function": "functions.transform.gold_sample_transform",
+    "sample_fraction": 0.01
+}

--- a/layer_03_gold/systemsPopulated.json
+++ b/layer_03_gold/systemsPopulated.json
@@ -1,0 +1,12 @@
+{
+    "simple_settings": "true",
+    "job_type": "silver_standard_batch",
+    "src_table_name": "edsm.silver.systemsPopulated",
+    "dst_table_name": "edsm.gold.systemsPopulated",
+    "business_key": [
+        "id"
+    ],
+    "ingest_time_column": "derived_ingest_time",
+    "transform_function": "functions.transform.gold_sample_transform",
+    "sample_fraction": 0.01
+}

--- a/layer_03_gold/systemsWithCoordinates.json
+++ b/layer_03_gold/systemsWithCoordinates.json
@@ -1,0 +1,12 @@
+{
+    "simple_settings": "true",
+    "job_type": "silver_standard_batch",
+    "src_table_name": "edsm.silver.systemsWithCoordinates",
+    "dst_table_name": "edsm.gold.systemsWithCoordinates",
+    "business_key": [
+        "id"
+    ],
+    "ingest_time_column": "derived_ingest_time",
+    "transform_function": "functions.transform.gold_sample_transform",
+    "sample_fraction": 0.01
+}

--- a/layer_03_gold/systemsWithoutCoordinates.json
+++ b/layer_03_gold/systemsWithoutCoordinates.json
@@ -1,0 +1,12 @@
+{
+    "simple_settings": "true",
+    "job_type": "silver_standard_batch",
+    "src_table_name": "edsm.silver.systemsWithoutCoordinates",
+    "dst_table_name": "edsm.gold.systemsWithoutCoordinates",
+    "business_key": [
+        "id"
+    ],
+    "ingest_time_column": "derived_ingest_time",
+    "transform_function": "functions.transform.gold_sample_transform",
+    "sample_fraction": 0.01
+}

--- a/tests/test_bronze_transform.py
+++ b/tests/test_bronze_transform.py
@@ -32,7 +32,7 @@ def dummy(*args, **kwargs):
 for name in [
     'concat','regexp_extract','date_format','current_timestamp','when','col',
     'to_timestamp','to_date','regexp_replace','sha2','lit','trim','struct',
-    'to_json','expr','transform','array'
+    'to_json','expr','transform','array','rand'
 ]:
     setattr(func_mod, name, dummy)
 


### PR DESCRIPTION
## Summary
- create gold layer configuration jsons for all silver tables
- add sampling transform function
- update tests to stub rand for pyspark

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68759c7bdf1c8329a512b64fd99feef5