### PR TITLE
Add custom transform usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@ This repository contains notebooks and utilities for ingesting data from the Eli
 
 For documentation, see [here](https://github.com/bryanlharris/Documentation).
 See [docs/silver.md](docs/silver.md) for details about configuring sequential and parallel silver tasks.
+See [docs/custom.md](docs/custom.md) for creating and using custom transforms.

--- a/docs/custom.md
+++ b/docs/custom.md
@@ -1,0 +1,29 @@
+# Custom transforms
+
+Add your own transformation functions in `functions/custom.py`. Each
+function should accept three arguments:
+
+```
+(df, settings, spark)
+```
+
+Reference the function by its dotted path in a settings file so it can be
+loaded with `functions.utility.get_function` when the job runs.
+
+```python
+# functions/custom.py
+def my_transform(df, settings, spark):
+    # custom logic here
+    return df
+```
+
+Settings snippet:
+
+```json
+{
+  "transform_function": "functions.custom.my_transform"
+}
+```
+
+When the job executes, ``get_function`` imports ``functions.custom`` and
+calls ``my_transform`` with the DataFrame, settings, and spark session.

--- a/functions/custom.py
+++ b/functions/custom.py
@@ -1,0 +1,22 @@
+"""Custom transform functions.
+
+Add project specific transformation functions here. Each function should
+accept ``(df, settings, spark)`` and return a DataFrame.
+
+Example
+-------
+
+.. code-block:: python
+
+    def my_transform(df, settings, spark):
+        return df
+
+Use the fully qualified path when referencing a custom transform in a
+settings file:
+
+.. code-block:: json
+
+    {
+      "transform_function": "functions.custom.my_transform"
+    }
+"""


### PR DESCRIPTION
## Summary
- remove the custom transform registry implementation
- explain how to write custom transforms with get_function
- link to the new doc from README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687974466ee48329b7971e75d6dc23f0