### PR TITLE
Remove sample options from gold settings

### DIFF
--- a/layer_03_gold/bodies7days.json
+++ b/layer_03_gold/bodies7days.json
@@ -10,7 +10,5 @@
     "transform_function": "functions.transform.sample_table",
     "sample_type": "simple",
     "sample_id_col": "id",
-    "sample_size": "1k",
-    "sample_fraction": 0.01,
-    "hash_modulus": 1000000
+    "sample_size": "1k"
 }

--- a/layer_03_gold/codex.json
+++ b/layer_03_gold/codex.json
@@ -15,7 +15,5 @@
     "transform_function": "functions.transform.sample_table",
     "sample_type": "simple",
     "sample_id_col": "id",
-    "sample_size": "1k",
-    "sample_fraction": 0.01,
-    "hash_modulus": 1000000
+    "sample_size": "1k"
 }

--- a/layer_03_gold/powerPlay.json
+++ b/layer_03_gold/powerPlay.json
@@ -11,7 +11,5 @@
     "transform_function": "functions.transform.sample_table",
     "sample_type": "simple",
     "sample_id_col": "id",
-    "sample_size": "1k",
-    "sample_fraction": 0.01,
-    "hash_modulus": 1000000
+    "sample_size": "1k"
 }

--- a/layer_03_gold/stations.json
+++ b/layer_03_gold/stations.json
@@ -12,7 +12,5 @@
     "transform_function": "functions.transform.sample_table",
     "sample_type": "simple",
     "sample_id_col": "id",
-    "sample_size": "1k",
-    "sample_fraction": 0.01,
-    "hash_modulus": 1000000
+    "sample_size": "1k"
 }

--- a/layer_03_gold/systemsPopulated.json
+++ b/layer_03_gold/systemsPopulated.json
@@ -10,7 +10,5 @@
     "transform_function": "functions.transform.sample_table",
     "sample_type": "simple",
     "sample_id_col": "id",
-    "sample_size": "1k",
-    "sample_fraction": 0.01,
-    "hash_modulus": 1000000
+    "sample_size": "1k"
 }

--- a/layer_03_gold/systemsWithCoordinates.json
+++ b/layer_03_gold/systemsWithCoordinates.json
@@ -10,7 +10,5 @@
     "transform_function": "functions.transform.sample_table",
     "sample_type": "simple",
     "sample_id_col": "id",
-    "sample_size": "1k",
-    "sample_fraction": 0.01,
-    "hash_modulus": 1000000
+    "sample_size": "1k"
 }

--- a/layer_03_gold/systemsWithoutCoordinates.json
+++ b/layer_03_gold/systemsWithoutCoordinates.json
@@ -10,7 +10,5 @@
     "transform_function": "functions.transform.sample_table",
     "sample_type": "simple",
     "sample_id_col": "id",
-    "sample_size": "1k",
-    "sample_fraction": 0.01,
-    "hash_modulus": 1000000
+    "sample_size": "1k"
 }


### PR DESCRIPTION
## Summary
- strip sampling options from all gold layer configuration JSON files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a16c9934c8329890218b2cd0ff044