### PR TITLE
Ensure gold samples overwrite existing data

### DIFF
--- a/docs/sampling.md
+++ b/docs/sampling.md
@@ -50,3 +50,13 @@ sampled_df = sample_table(df, settings, spark)
 
 This configuration returns roughly 5% of `df` using a stable hash based on a
 modulus of 2,000,000.
+
+## Persisting samples
+
+When using `sample_table` to materialize a sampled table, configure the job to
+overwrite the destination rather than merge updates. Add the following setting
+so old rows do not accumulate across runs:
+
+```json
+"write_function": "functions.write.overwrite_table"
+```

--- a/layer_03_gold/bodies7days.json
+++ b/layer_03_gold/bodies7days.json
@@ -10,5 +10,6 @@
     "transform_function": "functions.transform.sample_table",
     "sample_type": "simple",
     "sample_id_col": "id",
-    "sample_size": "1k"
+    "sample_size": "1k",
+    "write_function": "functions.write.overwrite_table"
 }

--- a/layer_03_gold/codex.json
+++ b/layer_03_gold/codex.json
@@ -15,5 +15,6 @@
     "transform_function": "functions.transform.sample_table",
     "sample_type": "simple",
     "sample_id_col": "systemid",
-    "sample_size": "1k"
+    "sample_size": "1k",
+    "write_function": "functions.write.overwrite_table"
 }

--- a/layer_03_gold/powerPlay.json
+++ b/layer_03_gold/powerPlay.json
@@ -11,5 +11,6 @@
     "transform_function": "functions.transform.sample_table",
     "sample_type": "simple",
     "sample_id_col": "id",
-    "sample_size": "1k"
+    "sample_size": "1k",
+    "write_function": "functions.write.overwrite_table"
 }

--- a/layer_03_gold/stations.json
+++ b/layer_03_gold/stations.json
@@ -12,5 +12,6 @@
     "transform_function": "functions.transform.sample_table",
     "sample_type": "simple",
     "sample_id_col": "id",
-    "sample_size": "1k"
+    "sample_size": "1k",
+    "write_function": "functions.write.overwrite_table"
 }

--- a/layer_03_gold/systemsPopulated.json
+++ b/layer_03_gold/systemsPopulated.json
@@ -10,5 +10,6 @@
     "transform_function": "functions.transform.sample_table",
     "sample_type": "simple",
     "sample_id_col": "id",
-    "sample_size": "1k"
+    "sample_size": "1k",
+    "write_function": "functions.write.overwrite_table"
 }

--- a/layer_03_gold/systemsWithCoordinates.json
+++ b/layer_03_gold/systemsWithCoordinates.json
@@ -10,5 +10,6 @@
     "transform_function": "functions.transform.sample_table",
     "sample_type": "simple",
     "sample_id_col": "id",
-    "sample_size": "1k"
+    "sample_size": "1k",
+    "write_function": "functions.write.overwrite_table"
 }

--- a/layer_03_gold/systemsWithoutCoordinates.json
+++ b/layer_03_gold/systemsWithoutCoordinates.json
@@ -10,5 +10,6 @@
     "transform_function": "functions.transform.sample_table",
     "sample_type": "simple",
     "sample_id_col": "id",
-    "sample_size": "1k"
+    "sample_size": "1k",
+    "write_function": "functions.write.overwrite_table"
 }


### PR DESCRIPTION
## Summary
- overwrite gold sampling tables each run so data doesn't accumulate
- document overwrite behavior in sampling guide

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a20ca8dc48329b9a75bf65cf7841b