### PR TITLE
Add sanity module docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,4 @@ See [docs/functions/read.md](docs/functions/read.md) for functions that read dat
 See [docs/functions/write.md](docs/functions/write.md) for functions that write and merge tables.
 See [docs/functions/history.md](docs/functions/history.md) for Delta transaction history utilities.
 See [docs/functions/quality.md](docs/functions/quality.md) for data quality helpers.
+See [docs/functions/sanity.md](docs/functions/sanity.md) for sanity helper functions.

--- a/docs/functions/sanity.md
+++ b/docs/functions/sanity.md
@@ -1,0 +1,27 @@
+# `functions.sanity`
+
+Helpers for validating configuration files and preparing the environment
+before ingestion runs.
+
+## `_discover_settings_files`
+
+Return dictionaries mapping table names to the JSON settings files for
+the bronze, silver and gold layers.
+
+## `validate_settings`
+
+Ensure each settings file contains the required keys for its layer.
+Extra requirements are enforced for certain write functions. Raises an
+exception when any file fails validation.
+
+## `initialize_empty_tables`
+
+Create empty Delta tables based on the configured transforms. Each table
+is built layer by layer starting from an empty DataFrame and written with
+`create_table_if_not_exists`.
+
+## `initialize_schemas_and_volumes`
+
+Create catalogs, schemas and external volumes referenced by the settings.
+History schemas are added when enabled. An error is raised if multiple
+catalogs or schemas are discovered.


### PR DESCRIPTION
## Summary
- document sanity helpers in docs/functions/sanity.md
- add reference to the new docs in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687a2154a7a88329882a35815732e400