### PR TITLE
Add docs for silver layer and rename dependency guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ This repository contains notebooks and utilities for ingesting data from the Eli
 For documentation, see [here](https://github.com/bryanlharris/Documentation).
 
 * [docs/bronze.md](docs/bronze.md) - Overview of the bronze layer.
-* [docs/silver.md](docs/silver.md) - Details about configuring sequential and parallel silver tasks.
+* [docs/silver.md](docs/silver.md) - Overview of how silver data is ingested, transformed and written.
+* [docs/silver_dependencies.md](docs/silver_dependencies.md) - Details about configuring sequential and parallel silver tasks.
 * [docs/ingest.md](docs/ingest.md) - Explanation of the ingest notebook.
 * [docs/sampling.md](docs/sampling.md) - Information on generating sample data.
 * [docs/job-definition.md](docs/job-definition.md) - Overview of the job-definition YAML.

--- a/docs/silver_dependencies.md
+++ b/docs/silver_dependencies.md
@@ -1,0 +1,38 @@
+# Silver layer dependencies
+
+This document explains how silver tables declare and resolve dependencies.  Silver processing is divided into **parallel** and **sequential** tasks.
+
+## `requires` field
+
+A silver table JSON file may include a `requires` key declaring dependencies on
+other silver tables. The value can be a single table name or a list of table
+names.
+
+Example:
+
+```json
+{
+  "job_type": "silver_standard_batch",
+  "src_table_name": "edsm.bronze.example",
+  "dst_table_name": "edsm.silver.example",
+  "requires": ["systemsPopulated", "stations"]
+}
+```
+
+Tables with a `requires` key are executed in the **sequential** silver loop.
+They are sorted so that each table appears after all tables it depends on.
+Tables without a `requires` key run in the **parallel** silver loop.
+
+## Workflow summary
+
+1. `00_job_settings.ipynb` scans all `layer_02_silver/*.json` files.
+2. Files without `requires` populate `silver_parallel`.
+3. Files with `requires` populate `silver_sequential`, ordered by dependency.
+4. `job-definition.yaml` defines two loops:
+   - `silver_parallel_loop` (runs tasks concurrently)
+   - `silver_sequential_loop` (runs tasks one at a time)
+
+Dependencies are only evaluated among tables in `silver_sequential`.
+If a sequential table depends on a parallel table, ensure the parallel loop
+finishes first or coordinate via other mechanisms. The job definition runs the
+parallel loop before the sequential loop to honour these prerequisites.


### PR DESCRIPTION
## Summary
- rename `docs/silver.md` to `docs/silver_dependencies.md`
- document the silver ingestion pipeline in a new `docs/silver.md`
- update README links

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a529e92d083298ccdddc785c1a5b0