### PR TITLE
Add drop history tables docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,4 @@ For documentation, see [here](https://github.com/bryanlharris/Documentation).
 * [docs/functions/sanity.md](docs/functions/sanity.md) - Sanity helper functions.
 * [docs/functions/rescue.md](docs/functions/rescue.md) - Table rescue utilities.
 * [docs/utilities/downloader.md](docs/utilities/downloader.md) - Details about fetching nightly dumps.
+* [docs/utilities/drop_history_tables.md](docs/utilities/drop_history_tables.md) - Notebook for removing history tables.

--- a/docs/utilities/drop_history_tables.md
+++ b/docs/utilities/drop_history_tables.md
@@ -1,0 +1,13 @@
+# Drop history tables notebook
+
+`utilities/drop_history_tables.ipynb` provides a simple helper to clean
+out Delta history artifacts.
+
+- Defines `drop_history_tables(spark, schema)` which lists all tables in the
+  given catalog schema and collects their names.
+- Drops every table that ends with `_file_version_history` or
+  `_transaction_history`.
+- The notebook calls the function for the `bronze` schema as an example.
+
+Run this notebook whenever you need to remove leftover history tables from a
+schema.


### PR DESCRIPTION
## Summary
- document drop_history_tables.ipynb in `docs/utilities`
- link from README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a6f01d4808329a4b9a88d36c896a2