### PR TITLE
Add history migration utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,4 @@ For documentation, see [here](https://github.com/bryanlharris/Documentation).
 * [docs/utilities/downloader.md](docs/utilities/downloader.md) - Details about fetching nightly dumps.
 * [docs/utilities/profile_silver_table.md](docs/utilities/profile_silver_table.md) - Notebook for generating DQX rules from a silver table.
 * [docs/utilities/drop_history_tables.md](docs/utilities/drop_history_tables.md) - Notebook for removing history tables.
+* [docs/utilities/migrate_history_tables.md](docs/utilities/migrate_history_tables.md) - Convert and remove old history tables.

--- a/docs/utilities/migrate_history_tables.md
+++ b/docs/utilities/migrate_history_tables.md
@@ -1,0 +1,8 @@
+# Migrate old history tables
+
+`utilities/migrate_history_tables.ipynb` converts `_file_version_history` and `_transaction_history` tables into the new `_file_ingestion_history` format.
+
+- Defines `migrate_history(schema, spark)` which scans the schema for old history tables.
+- Joins file and transaction history on version, merging the result into `<table>_file_ingestion_history`.
+- When the merge succeeds the old tables are dropped.
+- The notebook calls the function for `edsm.history` as an example.

--- a/utilities/migrate_history_tables.ipynb
+++ b/utilities/migrate_history_tables.ipynb
@@ -1,0 +1,80 @@
+{
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": 0,
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "cellMetadata": {
+            "byteLimit": 2048000,
+            "rowLimit": 10000
+          },
+          "inputWidgets": {},
+          "nuid": "f4ee2e60-cabc-4b55-bcea-f712c882df0a",
+          "showTitle": false,
+          "tableResultSettingsMap": {},
+          "title": ""
+        }
+      },
+      "outputs": [],
+      "source": [
+        "from functions.utility import create_table_if_not_exists\n",
+        "\n",
+        "def migrate_history(schema, spark):\n",
+        "    tables = spark.sql(f'SHOW TABLES IN {schema}').filter('isTemporary = false')\n",
+        "    table_names = [row.tableName for row in tables.collect()]\n",
+        "    file_map = {}\n",
+        "    trans_map = {}\n",
+        "    for name in table_names:\n",
+        "        if name.endswith('_file_version_history'):\n",
+        "            base = name[:-len('_file_version_history')]\n",
+        "            file_map[base] = name\n",
+        "        elif name.endswith('_transaction_history'):\n",
+        "            base = name[:-len('_transaction_history')]\n",
+        "            trans_map[base] = name\n",
+        "    for base in sorted(set(file_map) & set(trans_map)):\n",
+        "        file_tbl = f'{schema}.{file_map[base]}'\n",
+        "        trans_tbl = f'{schema}.{trans_map[base]}'\n",
+        "        new_tbl = f'{schema}.{base}_file_ingestion_history'\n",
+        "        print(f'Merging {file_tbl} and {trans_tbl} into {new_tbl}')\n",
+        "        try:\n",
+        "            file_df = spark.table(file_tbl).selectExpr('version', 'explode(file_path) as file_path')\n",
+        "            trans_df = spark.table(trans_tbl)\n",
+        "            join_col = 'version' if 'version' in trans_df.columns else 'primary_key'\n",
+        "            joined = file_df.join(trans_df, join_col).select('file_path', *trans_df.columns)\n",
+        "            create_table_if_not_exists(joined, new_tbl, spark)\n",
+        "            joined.createOrReplaceTempView('df')\n",
+        "            spark.sql(f'''\nmerge into {new_tbl} as t\nusing df as s\n  on t.file_path = s.file_path and t.version = s.version\nwhen matched then update set *\nwhen not matched then insert *''')\n",
+        "            spark.sql(f'drop table if exists {file_tbl}')\n",
+        "            spark.sql(f'drop table if exists {trans_tbl}')\n",
+        "            print(f'Successfully migrated {base}')\n",
+        "        except Exception as e:\n",
+        "            print(f'Failed to migrate {base}: {e}')\n",
+        "\n",
+        "migrate_history('edsm.history', spark)\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "application/vnd.databricks.v1+notebook": {
+      "computePreferences": null,
+      "dashboards": [],
+      "environmentMetadata": {
+        "base_environment": "",
+        "environment_version": "2"
+      },
+      "inputWidgetPreferences": null,
+      "language": "python",
+      "notebookMetadata": {
+        "pythonIndentUnit": 4
+      },
+      "notebookName": "drop_history_tables",
+      "widgets": {}
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}


### PR DESCRIPTION
## Summary
- create `migrate_history_tables.ipynb` utility to convert old history tables
- document notebook usage
- reference documentation from README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687abee29c788329b53f672f598c4c96