### PR TITLE
Move parse_si function

### DIFF
--- a/docs/functions/transform.md
+++ b/docs/functions/transform.md
@@ -117,9 +117,4 @@ Parameters
 - **settings**: must include `ingest_time_column`
 - **spark**: Spark session (unused)
 
-### `parse_si`
-Return a numeric value converted from a string using SI notation (k, m, g, t).
-
-Parameters
-- **value**: string or numeric value to convert
 

--- a/docs/functions/utility.md
+++ b/docs/functions/utility.md
@@ -50,3 +50,10 @@ Print the mapping between streaming batch IDs and bronze versions by reading Del
 
 Create `<dst_table_name>_bad_records` from JSON files in `badRecordsPath`. If no files are present the table is dropped. An exception is raised if the table exists after creation, signalling that bad records were found.
 
+## `parse_si`
+
+Return a numeric value converted from a string using SI notation (k, m, g, t).
+
+Parameters
+- **value**: string or numeric value to convert
+

--- a/functions/transform.py
+++ b/functions/transform.py
@@ -40,19 +40,7 @@ from pyspark.sql.functions import (
 )
 import re
 
-
-def parse_si(value):
-    """Return ``value`` converted to a float using SI notation."""
-
-    if isinstance(value, (int, float)):
-        return float(value)
-    if not isinstance(value, str):
-        raise TypeError("value must be a number or string")
-    s = value.strip().lower()
-    scale = {"k": 1e3, "m": 1e6, "g": 1e9, "t": 1e12}
-    if s and s[-1] in scale:
-        return float(s[:-1]) * scale[s[-1]]
-    return float(s)
+from .utility import parse_si
 
 
 def bronze_standard_transform(df, settings, spark):

--- a/functions/utility.py
+++ b/functions/utility.py
@@ -322,3 +322,17 @@ def create_bad_records_table(settings, spark):
 
     if spark.catalog.tableExists(f"{dst_table_name}_bad_records"):
         raise Exception(f"Bad records table exists: {dst_table_name}_bad_records")
+
+
+def parse_si(value):
+    """Return ``value`` converted to a float using SI notation."""
+
+    if isinstance(value, (int, float)):
+        return float(value)
+    if not isinstance(value, str):
+        raise TypeError("value must be a number or string")
+    s = value.strip().lower()
+    scale = {"k": 1e3, "m": 1e6, "g": 1e9, "t": 1e12}
+    if s and s[-1] in scale:
+        return float(s[:-1]) * scale[s[-1]]
+    return float(s)


### PR DESCRIPTION
## Summary
- move `parse_si` from `transform.py` into `utility.py`
- adjust imports and documentation
- revert package `__init__` to static imports for submodules

## Testing
- `pytest -q` *(fails: ImportError from dummy pyspark setup)*

------
https://chatgpt.com/codex/tasks/task_e_687ada846f988329b0dab98ad663b868