### PR TITLE
Track WRITE operations in history

### DIFF
--- a/docs/functions/history.md
+++ b/docs/functions/history.md
@@ -4,7 +4,7 @@ Utilities for capturing Delta transaction details and file lineage.
 
 ## `describe_and_filter_history`
 
-Return a sorted list of Delta versions that were produced by `STREAMING UPDATE` or `MERGE` operations.
+Return a sorted list of Delta versions that were produced by `STREAMING UPDATE`, `WRITE` or `MERGE` operations.
 
 ## `build_and_merge_file_history`
 

--- a/functions/history.py
+++ b/functions/history.py
@@ -2,16 +2,20 @@ from .utility import create_table_if_not_exists, truncate_table_if_exists
 from pyspark.sql.functions import col, lit, current_timestamp
 
 def describe_and_filter_history(full_table_name, spark):
-    """Return ordered versions that correspond to streaming updates or merges."""
+    """Return ordered versions produced by streaming updates, writes, or merges."""
 
     hist = spark.sql(f"describe history {full_table_name}")
-    update_or_merge_version_rows = (
-        hist.filter((col("operation") == "STREAMING UPDATE") | (col("operation") == "MERGE"))
+    version_rows = (
+        hist.filter(
+            (col("operation") == "STREAMING UPDATE")
+            | (col("operation") == "MERGE")
+            | (col("operation") == "WRITE")
+        )
         .select("version")
         .distinct()
         .collect()
     )
-    version_list = [row["version"] for row in update_or_merge_version_rows]
+    version_list = [row["version"] for row in version_rows]
     version_list = sorted(version_list)
     return version_list
 


### PR DESCRIPTION
## Summary
- capture WRITE operations in history version list
- document WRITE as a tracked operation

## Testing
- `pytest -q`
- ❌ `pyspark` local ingestion (delta-spark download blocked)

------
https://chatgpt.com/codex/tasks/task_e_687b867be380832984cfe77fb9960eed