### PR TITLE
Add row hash to history table

### DIFF
--- a/docs/functions/history.md
+++ b/docs/functions/history.md
@@ -11,9 +11,12 @@ Return a sorted list of Delta versions that were produced by `STREAMING UPDATE`,
 Create or update `<table>_file_ingestion_history` with new file paths for each
 tracked version. Each row stores the file path together with the full
 transaction details from `DESCRIBE HISTORY` plus an ``ingest_time`` column
-recording when the row was inserted. Column types are preserved so struct and
-map fields remain intact. Versions that cannot be read because a referenced
-file is missing are skipped.
+recording when the row was inserted. A hash of ``file_path``, ``table_name``,
+``timestamp`` and ``ingest_time`` is stored in ``row_hash`` so duplicate rows are
+ignored on merge.
+This prevents duplicates if the Delta table version is reset (for example after
+cloning). Column types are preserved so struct and map fields remain intact.
+Versions that cannot be read because a referenced file is missing are skipped.
 
 ## `transaction_history`
 

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -30,6 +30,11 @@ functions_pkg = types.ModuleType('functions')
 functions_pkg.__path__ = [str(pkg_path)]
 sys.modules.setdefault('functions', functions_pkg)
 
+# Stub out functions.transform.add_row_hash to avoid pyspark dependencies
+transform_mod = types.ModuleType('functions.transform')
+transform_mod.add_row_hash = lambda df, cols, name='row_hash', use_row_hash=False: df
+sys.modules['functions.transform'] = transform_mod
+
 # Import history module dynamically
 hist_path = pathlib.Path(__file__).resolve().parents[1] / 'functions' / 'history.py'
 spec = importlib.util.spec_from_file_location('functions.history', hist_path)


### PR DESCRIPTION
## Summary
- generate row_hash when building history table
- use row_hash for merge logic
- keep test_history working with stubbed transform module
- document row_hash usage in history function docs
- hash only path, table, timestamp and ingest_time

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687b9315f2888329b7528b15f8822f69