### PR TITLE
Add S3 root validation

### DIFF
--- a/docs/functions/config.md
+++ b/docs/functions/config.md
@@ -34,3 +34,6 @@ The provided job types are:
 
 ``S3_ROOT_LANDING`` and ``S3_ROOT_UTILITY`` define the base S3 locations
 for external landing and utility volumes.
+Both values should include a trailing ``/``.  When omitted, it will be
+appended by ``sanity.validate_s3_roots`` but updating ``config.py`` is
+recommended.

--- a/docs/functions/sanity.md
+++ b/docs/functions/sanity.md
@@ -12,7 +12,9 @@ the bronze, silver and gold layers.
 
 Ensure each settings file contains the required keys for its layer.
 Extra requirements are enforced for certain write functions. Raises an
-exception when any file fails validation.
+exception when any file fails validation. When settings are valid it also
+calls `validate_s3_roots` to warn about missing trailing slashes in the
+S3 root constants.
 
 ## `initialize_empty_tables`
 
@@ -25,3 +27,9 @@ is built layer by layer starting from an empty DataFrame and written with
 Create catalogs, schemas and external volumes referenced by the settings.
 History schemas are added when enabled. An error is raised if multiple
 catalogs or schemas are discovered.
+
+## `validate_s3_roots`
+
+Ensure ``S3_ROOT_LANDING`` and ``S3_ROOT_UTILITY`` include a trailing
+``/``. Missing slashes are appended and a warning is printed so the
+values can be updated in ``functions.config``.

--- a/docs/job_settings.md
+++ b/docs/job_settings.md
@@ -15,6 +15,7 @@ Silver files are divided into parallel and sequential lists based on the presenc
 Each section of `job_settings` is stored in a Databricks task value so downstream notebooks can access the configuration.
 Finally the notebook runs several sanity checks:
 
-1. `validate_settings` verifies the settings are well formed.
+1. `validate_settings` verifies the settings are well formed and warns if the
+   S3 root paths are missing a trailing `/`.
 2. `initialize_schemas_and_volumes` ensures catalogs and volumes exist.
 3. `initialize_empty_tables` creates any empty destination tables.

--- a/functions/sanity.py
+++ b/functions/sanity.py
@@ -9,7 +9,8 @@ from functions.utility import (
     create_volume_if_not_exists,
     catalog_exists,
 )
-from functions.config import PROJECT_ROOT
+from functions import config
+PROJECT_ROOT = config.PROJECT_ROOT
 
 
 def _discover_settings_files():
@@ -29,6 +30,28 @@ def _discover_settings_files():
     }
 
     return bronze_files, silver_files, gold_files
+
+
+def validate_s3_roots():
+    """Ensure S3 root constants end with a trailing slash."""
+
+    updated = False
+
+    if not config.S3_ROOT_LANDING.endswith("/"):
+        config.S3_ROOT_LANDING += "/"
+        print(
+            "\tWARNING: Added trailing '/' to S3_ROOT_LANDING; update config.py to include it."
+        )
+        updated = True
+
+    if not config.S3_ROOT_UTILITY.endswith("/"):
+        config.S3_ROOT_UTILITY += "/"
+        print(
+            "\tWARNING: Added trailing '/' to S3_ROOT_UTILITY; update config.py to include it."
+        )
+        updated = True
+
+    return updated
 
 def validate_settings(dbutils):
     """Ensure all settings files contain required keys before processing."""
@@ -84,6 +107,9 @@ def validate_settings(dbutils):
         raise RuntimeError("Sanity check failed: "+", ".join(errs))
     else:
         print("Sanity check: Validate settings check passed.")
+
+    # Validate S3 root configuration after settings are confirmed
+    validate_s3_roots()
 
 
 

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -1,0 +1,66 @@
+import sys
+import types
+import pathlib
+
+# Stub minimal pyspark modules so functions can be imported without pyspark
+pyspark = types.ModuleType('pyspark')
+sql = types.ModuleType('pyspark.sql')
+types_mod = types.ModuleType('pyspark.sql.types')
+sql.types = types_mod
+pyspark.sql = sql
+sys.modules.setdefault('pyspark', pyspark)
+sys.modules.setdefault('pyspark.sql', sql)
+sys.modules.setdefault('pyspark.sql.types', types_mod)
+types_mod.StructType = type('StructType', (), {})
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from functions import sanity, config
+
+
+def test_no_warning_when_slash_present(capsys, monkeypatch):
+    monkeypatch.setattr(config, 'S3_ROOT_LANDING', 's3://landing/')
+    monkeypatch.setattr(config, 'S3_ROOT_UTILITY', 's3://utility/')
+    sanity.validate_s3_roots()
+    out = capsys.readouterr().out
+    assert out == ''
+    assert config.S3_ROOT_LANDING.endswith('/')
+    assert config.S3_ROOT_UTILITY.endswith('/')
+
+
+def test_append_slash_and_warn(capsys, monkeypatch):
+    monkeypatch.setattr(config, 'S3_ROOT_LANDING', 's3://landing')
+    monkeypatch.setattr(config, 'S3_ROOT_UTILITY', 's3://utility')
+    sanity.validate_s3_roots()
+    out = capsys.readouterr().out
+    assert 'WARNING' in out
+    assert config.S3_ROOT_LANDING == 's3://landing/'
+    assert config.S3_ROOT_UTILITY == 's3://utility/'
+
+
+class DummyDbutils:
+    class Jobs:
+        class TaskValues:
+            @staticmethod
+            def get(taskKey=None, key=None):
+                return None
+
+        def __init__(self):
+            self.taskValues = self.TaskValues()
+
+    def __init__(self):
+        self.jobs = self.Jobs()
+
+
+def test_validate_settings_runs_s3_validation(capsys, monkeypatch):
+    monkeypatch.setattr(config, 'S3_ROOT_LANDING', 's3://landing')
+    monkeypatch.setattr(config, 'S3_ROOT_UTILITY', 's3://utility')
+
+    monkeypatch.setattr(sanity, '_discover_settings_files', lambda: ({}, {}, {}))
+    sanity.validate_settings(DummyDbutils())
+
+    out = capsys.readouterr().out
+    assert 'Sanity check: Validate settings check passed.' in out
+    assert 'WARNING' in out
+    assert config.S3_ROOT_LANDING.endswith('/')
+    assert config.S3_ROOT_UTILITY.endswith('/')


### PR DESCRIPTION
## Summary
- add `validate_s3_roots` helper in `functions.sanity`
- run `validate_s3_roots` from `validate_settings`
- document the automatic call and trailing slash check
- tests for integration with `validate_settings`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ce9b9e2c08329a38eac46762d0d5a