### PR TITLE
Add OBJECT_OWNER constant and robust owner setting

### DIFF
--- a/functions/config.py
+++ b/functions/config.py
@@ -7,6 +7,9 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 S3_ROOT_LANDING = "s3://edsm/landing/"
 S3_ROOT_UTILITY = "s3://edsm/utility/"
 
+# Default owner for tables, schemas and volumes created by the utilities
+OBJECT_OWNER = "bryanlharris@me.com"
+
 # Map short ``job_type`` names to ingest function combinations.
 JOB_TYPE_MAP = {
     "bronze_standard_streaming": {

--- a/tests/test_volume_creation.py
+++ b/tests/test_volume_creation.py
@@ -105,7 +105,7 @@ def test_create_volume_message_depends_on_existence(capsys):
     utility.create_volume_if_not_exists('cat', 'sch', 'landing', spark)
     out = capsys.readouterr().out
     assert "Volume did not exist and was created" in out
-    assert "Owner changed to admins" in out
+    assert f"Owner changed to {config.OBJECT_OWNER}" in out
 
     # Mark volume as existing and call again - no message expected
     spark.volumes.add(('cat', 'sch', 'landing'))
@@ -120,7 +120,7 @@ def test_create_schema_message_depends_on_existence(capsys):
     utility.create_schema_if_not_exists('cat', 'sch', spark)
     out = capsys.readouterr().out
     assert "Schema did not exist and was created" in out
-    assert "Owner changed to admins" in out
+    assert f"Owner changed to {config.OBJECT_OWNER}" in out
 
     # Already present
     spark.schemas.add(('cat', 'sch'))
@@ -141,9 +141,9 @@ def test_volume_root_without_trailing_slash(monkeypatch):
 def test_owner_alter_queries_executed():
     spark = DummySpark()
     utility.create_schema_if_not_exists('cat', 'sch', spark)
-    assert any(q.startswith('ALTER SCHEMA cat.sch OWNER TO `admins`') for q in spark.queries)
+    assert any(q.startswith(f'ALTER SCHEMA cat.sch OWNER TO `{config.OBJECT_OWNER}`') for q in spark.queries)
 
     spark = DummySpark()
     utility.create_volume_if_not_exists('cat', 'sch', 'utility', spark)
-    assert any(q.startswith('ALTER VOLUME cat.sch.utility OWNER TO `admins`') for q in spark.queries)
+    assert any(q.startswith(f'ALTER VOLUME cat.sch.utility OWNER TO `{config.OBJECT_OWNER}`') for q in spark.queries)
 


### PR DESCRIPTION
## Summary
- add new `OBJECT_OWNER` setting in config
- update utility owner logic to use configurable owner and ignore errors
- fix volume creation tests to expect new owner name

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d078bada08329953046aa6f3c7dc4