### PR TITLE
Implement owner set message

### DIFF
--- a/functions/utility.py
+++ b/functions/utility.py
@@ -260,6 +260,12 @@ def _ensure_admin_owner(obj_type: str, name: str, spark) -> None:
             print(f"\tINFO: Owner changed to {OBJECT_OWNER} for {obj_type} {name}.")
         except Exception:
             print(f"\tWARNING: Failed to change owner for {obj_type} {name}.")
+    elif not owner:
+        try:
+            spark.sql(alter_map[obj_type])
+            print(f"\tINFO: Owner set to {OBJECT_OWNER} for {obj_type} {name}.")
+        except Exception:
+            print(f"\tWARNING: Failed to set owner for {obj_type} {name}.")
 
 
 def create_table_if_not_exists(df, dst_table_name, spark):


### PR DESCRIPTION
## Summary
- ensure `_ensure_admin_owner` reports when setting an owner for the first time
- support owner-missing case in test helper
- add regression test for missing owner message

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d37887b748329a540aeb2fbe6807d