### PR TITLE
Log history schema creation

### DIFF
--- a/docs/functions/sanity.md
+++ b/docs/functions/sanity.md
@@ -31,8 +31,9 @@ catalogs or schemas are discovered.
 ## `warn_missing_history_schema`
 
 Check whether the history schema referenced by the settings exists. If the
-schema is missing, a warning message is printed so it can be created prior to
-ingestion.
+schema is missing, a warning message is printed and the schema is created using
+`create_schema_if_not_exists`, producing the same INFO message as other schema
+creations.
 
 ## `validate_s3_roots`
 

--- a/docs/job_settings.md
+++ b/docs/job_settings.md
@@ -18,5 +18,5 @@ Finally the notebook runs several sanity checks:
 1. `validate_settings` verifies the settings are well formed and warns if the
    S3 root paths are missing a trailing `/`.
 2. `initialize_schemas_and_volumes` ensures catalogs and volumes exist.
-3. `warn_missing_history_schema` prints a warning when the configured history schema is missing.
+3. `warn_missing_history_schema` prints a warning and creates the history schema when it is missing.
 4. `initialize_empty_tables` creates any empty destination tables.

--- a/functions/sanity.py
+++ b/functions/sanity.py
@@ -257,6 +257,7 @@ def warn_missing_history_schema(spark):
             checked.add(key)
             if not schema_exists(catalog, history_schema, spark):
                 print(f"\tWARNING: History schema does not exist: {catalog}.{history_schema}")
+                create_schema_if_not_exists(catalog, history_schema, spark)
                 missing = True
 
     if not missing:

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -78,8 +78,10 @@ def test_warn_missing_history_schema(capsys, monkeypatch):
         return builtins.open(p, *a, **k)
 
     monkeypatch.setattr(sanity, 'schema_exists', lambda catalog, schema, spark: False)
+    monkeypatch.setattr(sanity, 'create_schema_if_not_exists', lambda c, s, sp: print(f"\tINFO: Schema did not exist and was created: {c}.{s}."))
     monkeypatch.setattr(builtins, 'open', fake_open)
 
     sanity.warn_missing_history_schema(None)
     out = capsys.readouterr().out
     assert 'WARNING' in out
+    assert 'Schema did not exist and was created' in out


### PR DESCRIPTION
## Summary
- create missing history schemas automatically in `warn_missing_history_schema`
- document updated behaviour
- adjust unit test for new INFO message

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d375f076883298d9bf481a3bc2cff