### PR TITLE
Add is_null DQX check

### DIFF
--- a/docs/functions/dq_checks.md
+++ b/docs/functions/dq_checks.md
@@ -33,6 +33,10 @@ Wrapper around `matches_regex_list` for a single pattern.
 
 Return a column that fails when the value is equal to zero.
 
+## `is_null`
+
+Return a column that fails when the value is not null.
+
 ## `starts_with_prefixes`
 
 Return a column that fails when the value does not start with any of the provided prefixes.

--- a/functions/dq_checks.py
+++ b/functions/dq_checks.py
@@ -92,6 +92,21 @@ def pattern_match(column, pattern):
     return matches_regex_list(column, [pattern])
 
 
+def is_null(column):
+    """Return a column validating ``column`` is null."""
+
+    from pyspark.sql import functions as F
+
+    col_expr = F.col(column) if isinstance(column, str) else column
+    condition = col_expr.isNotNull()
+    alias = f"{str(column).replace('.', '_')}_is_null"
+    return (
+        F.when(condition, F.lit("Value is not null"))
+        .otherwise(F.lit(None))
+        .alias(alias)
+    )
+
+
 def is_nonzero(column):
     """Return a column validating ``column`` is not zero."""
 

--- a/functions/quality.py
+++ b/functions/quality.py
@@ -19,6 +19,7 @@ from .dq_checks import (
     max_length,
     matches_regex_list,
     pattern_match,
+    is_null,
     is_nonzero,
     starts_with_prefixes,
 )
@@ -64,6 +65,7 @@ def apply_dqx_checks(df: Any, settings: dict, spark: Any) -> Tuple[Any, Any]:
         "min_max": min_max,
         "is_in": is_in,
         "is_not_null_or_empty": is_not_null_or_empty,
+        "is_null": is_null,
         "max_length": max_length,
         "matches_regex_list": matches_regex_list,
         "pattern_match": pattern_match,

--- a/layer_01_bronze/bodies7days.json
+++ b/layer_01_bronze/bodies7days.json
@@ -639,5 +639,16 @@
         ],
         "type": "struct"
     },
-    "history_schema": "history"
+    "history_schema": "history",
+    "dqx_checks": [
+        {
+            "name": "rescued_data_empty",
+            "check": {
+                "function": "is_null",
+                "arguments": {
+                    "column": "_rescued_data"
+                }
+            }
+        }
+    ]
 }

--- a/layer_01_bronze/codex.json
+++ b/layer_01_bronze/codex.json
@@ -63,5 +63,16 @@
         ],
         "type": "struct"
     },
-    "history_schema": "history"
+    "history_schema": "history",
+    "dqx_checks": [
+        {
+            "name": "rescued_data_empty",
+            "check": {
+                "function": "is_null",
+                "arguments": {
+                    "column": "_rescued_data"
+                }
+            }
+        }
+    ]
 }

--- a/layer_01_bronze/examples/example.json
+++ b/layer_01_bronze/examples/example.json
@@ -1,5 +1,16 @@
 {
     "simple_settings": "true",
     "job_type": "bronze_standard_streaming",
-    "dst_table_name": "edsm.bronze.example"
+    "dst_table_name": "edsm.bronze.example",
+    "dqx_checks": [
+        {
+            "name": "rescued_data_empty",
+            "check": {
+                "function": "is_null",
+                "arguments": {
+                    "column": "_rescued_data"
+                }
+            }
+        }
+    ]
 }

--- a/layer_01_bronze/powerPlay.json
+++ b/layer_01_bronze/powerPlay.json
@@ -103,5 +103,16 @@
         ],
         "type": "struct"
     },
-    "history_schema": "history"
+    "history_schema": "history",
+    "dqx_checks": [
+        {
+            "name": "rescued_data_empty",
+            "check": {
+                "function": "is_null",
+                "arguments": {
+                    "column": "_rescued_data"
+                }
+            }
+        }
+    ]
 }

--- a/layer_01_bronze/stations.json
+++ b/layer_01_bronze/stations.json
@@ -319,5 +319,16 @@
         ],
         "type": "struct"
     },
-    "history_schema": "history"
+    "history_schema": "history",
+    "dqx_checks": [
+        {
+            "name": "rescued_data_empty",
+            "check": {
+                "function": "is_null",
+                "arguments": {
+                    "column": "_rescued_data"
+                }
+            }
+        }
+    ]
 }

--- a/layer_01_bronze/systemsPopulated.json
+++ b/layer_01_bronze/systemsPopulated.json
@@ -1089,5 +1089,16 @@
         ],
         "type": "struct"
     },
-    "history_schema": "history"
+    "history_schema": "history",
+    "dqx_checks": [
+        {
+            "name": "rescued_data_empty",
+            "check": {
+                "function": "is_null",
+                "arguments": {
+                    "column": "_rescued_data"
+                }
+            }
+        }
+    ]
 }

--- a/layer_01_bronze/systemsWithCoordinates.json
+++ b/layer_01_bronze/systemsWithCoordinates.json
@@ -74,5 +74,16 @@
         ],
         "type": "struct"
     },
-    "history_schema": "history"
+    "history_schema": "history",
+    "dqx_checks": [
+        {
+            "name": "rescued_data_empty",
+            "check": {
+                "function": "is_null",
+                "arguments": {
+                    "column": "_rescued_data"
+                }
+            }
+        }
+    ]
 }

--- a/layer_01_bronze/systemsWithCoordinates7days.json
+++ b/layer_01_bronze/systemsWithCoordinates7days.json
@@ -73,5 +73,16 @@
         ],
         "type": "struct"
     },
-    "history_schema": "history"
+    "history_schema": "history",
+    "dqx_checks": [
+        {
+            "name": "rescued_data_empty",
+            "check": {
+                "function": "is_null",
+                "arguments": {
+                    "column": "_rescued_data"
+                }
+            }
+        }
+    ]
 }

--- a/layer_01_bronze/systemsWithoutCoordinates.json
+++ b/layer_01_bronze/systemsWithoutCoordinates.json
@@ -79,5 +79,16 @@
         ],
         "type": "struct"
     },
-    "history_schema": "history"
+    "history_schema": "history",
+    "dqx_checks": [
+        {
+            "name": "rescued_data_empty",
+            "check": {
+                "function": "is_null",
+                "arguments": {
+                    "column": "_rescued_data"
+                }
+            }
+        }
+    ]
 }

--- a/layer_02_silver/bodies7days.json
+++ b/layer_02_silver/bodies7days.json
@@ -15,5 +15,16 @@
     "data_type_map": {
         "date": "timestamp"
     },
-    "ingest_time_column": "derived_ingest_time"
+    "ingest_time_column": "derived_ingest_time",
+    "dqx_checks": [
+        {
+            "name": "rescued_data_empty",
+            "check": {
+                "function": "is_null",
+                "arguments": {
+                    "column": "_rescued_data"
+                }
+            }
+        }
+    ]
 }

--- a/layer_02_silver/codex.json
+++ b/layer_02_silver/codex.json
@@ -3,7 +3,11 @@
     "job_type": "silver_standard_batch",
     "src_table_name": "edsm.bronze.codex",
     "dst_table_name": "edsm.silver.codex",
-    "requires": ["systemswithcoordinates", "stations", "powerplay" ],
+    "requires": [
+        "systemswithcoordinates",
+        "stations",
+        "powerplay"
+    ],
     "business_key": [
         "name",
         "region",
@@ -23,5 +27,16 @@
     "data_type_map": {
         "date": "timestamp"
     },
-    "ingest_time_column": "derived_ingest_time"
+    "ingest_time_column": "derived_ingest_time",
+    "dqx_checks": [
+        {
+            "name": "rescued_data_empty",
+            "check": {
+                "function": "is_null",
+                "arguments": {
+                    "column": "_rescued_data"
+                }
+            }
+        }
+    ]
 }

--- a/layer_02_silver/examples/example.json
+++ b/layer_02_silver/examples/example.json
@@ -3,5 +3,18 @@
     "job_type": "silver_standard_batch",
     "src_table_name": "edsm.bronze.example",
     "dst_table_name": "edsm.silver.example",
-    "business_key": ["id"]
+    "business_key": [
+        "id"
+    ],
+    "dqx_checks": [
+        {
+            "name": "rescued_data_empty",
+            "check": {
+                "function": "is_null",
+                "arguments": {
+                    "column": "_rescued_data"
+                }
+            }
+        }
+    ]
 }

--- a/layer_02_silver/powerPlay.json
+++ b/layer_02_silver/powerPlay.json
@@ -22,7 +22,9 @@
             "name": "id_not_null",
             "check": {
                 "function": "is_not_null",
-                "arguments": {"column": "id"}
+                "arguments": {
+                    "column": "id"
+                }
             }
         },
         {
@@ -136,6 +138,15 @@
                         "Investment",
                         "Election"
                     ]
+                }
+            }
+        },
+        {
+            "name": "rescued_data_empty",
+            "check": {
+                "function": "is_null",
+                "arguments": {
+                    "column": "_rescued_data"
                 }
             }
         }

--- a/layer_02_silver/stations.json
+++ b/layer_02_silver/stations.json
@@ -29,5 +29,16 @@
     "data_type_map": {
         "date": "timestamp"
     },
-    "ingest_time_column": "derived_ingest_time"
+    "ingest_time_column": "derived_ingest_time",
+    "dqx_checks": [
+        {
+            "name": "rescued_data_empty",
+            "check": {
+                "function": "is_null",
+                "arguments": {
+                    "column": "_rescued_data"
+                }
+            }
+        }
+    ]
 }

--- a/layer_02_silver/systemsPopulated.json
+++ b/layer_02_silver/systemsPopulated.json
@@ -22,5 +22,16 @@
     "data_type_map": {
         "date": "timestamp"
     },
-    "ingest_time_column": "derived_ingest_time"
+    "ingest_time_column": "derived_ingest_time",
+    "dqx_checks": [
+        {
+            "name": "rescued_data_empty",
+            "check": {
+                "function": "is_null",
+                "arguments": {
+                    "column": "_rescued_data"
+                }
+            }
+        }
+    ]
 }

--- a/layer_02_silver/systemsWithCoordinates.json
+++ b/layer_02_silver/systemsWithCoordinates.json
@@ -117,6 +117,15 @@
                     "pattern": "^/Volumes/edsm/bronze/landing/data/\\d{8}/systemsWithCoordinates7days\\.json$"
                 }
             }
+        },
+        {
+            "name": "rescued_data_empty",
+            "check": {
+                "function": "is_null",
+                "arguments": {
+                    "column": "_rescued_data"
+                }
+            }
         }
     ]
 }

--- a/layer_02_silver/systemsWithoutCoordinates.json
+++ b/layer_02_silver/systemsWithoutCoordinates.json
@@ -15,5 +15,16 @@
     "data_type_map": {
         "date": "timestamp"
     },
-    "ingest_time_column": "derived_ingest_time"
+    "ingest_time_column": "derived_ingest_time",
+    "dqx_checks": [
+        {
+            "name": "rescued_data_empty",
+            "check": {
+                "function": "is_null",
+                "arguments": {
+                    "column": "_rescued_data"
+                }
+            }
+        }
+    ]
 }

--- a/layer_03_gold/bodies7days.json
+++ b/layer_03_gold/bodies7days.json
@@ -11,5 +11,16 @@
     "sample_type": "simple",
     "sample_id_col": "id",
     "sample_size": "1k",
-    "write_function": "functions.write.overwrite_table"
+    "write_function": "functions.write.overwrite_table",
+    "dqx_checks": [
+        {
+            "name": "rescued_data_empty",
+            "check": {
+                "function": "is_null",
+                "arguments": {
+                    "column": "_rescued_data"
+                }
+            }
+        }
+    ]
 }

--- a/layer_03_gold/codex.json
+++ b/layer_03_gold/codex.json
@@ -16,5 +16,16 @@
     "sample_type": "simple",
     "sample_id_col": "systemid",
     "sample_size": "1k",
-    "write_function": "functions.write.overwrite_table"
+    "write_function": "functions.write.overwrite_table",
+    "dqx_checks": [
+        {
+            "name": "rescued_data_empty",
+            "check": {
+                "function": "is_null",
+                "arguments": {
+                    "column": "_rescued_data"
+                }
+            }
+        }
+    ]
 }

--- a/layer_03_gold/examples/example.json
+++ b/layer_03_gold/examples/example.json
@@ -3,5 +3,18 @@
     "job_type": "gold_standard_batch",
     "src_table_name": "edsm.silver.example",
     "dst_table_name": "edsm.gold.example",
-    "business_key": ["id"]
+    "business_key": [
+        "id"
+    ],
+    "dqx_checks": [
+        {
+            "name": "rescued_data_empty",
+            "check": {
+                "function": "is_null",
+                "arguments": {
+                    "column": "_rescued_data"
+                }
+            }
+        }
+    ]
 }

--- a/layer_03_gold/powerPlay.json
+++ b/layer_03_gold/powerPlay.json
@@ -12,5 +12,16 @@
     "sample_type": "simple",
     "sample_id_col": "id",
     "sample_size": "1k",
-    "write_function": "functions.write.overwrite_table"
+    "write_function": "functions.write.overwrite_table",
+    "dqx_checks": [
+        {
+            "name": "rescued_data_empty",
+            "check": {
+                "function": "is_null",
+                "arguments": {
+                    "column": "_rescued_data"
+                }
+            }
+        }
+    ]
 }

--- a/layer_03_gold/stations.json
+++ b/layer_03_gold/stations.json
@@ -13,5 +13,16 @@
     "sample_type": "simple",
     "sample_id_col": "id",
     "sample_size": "1k",
-    "write_function": "functions.write.overwrite_table"
+    "write_function": "functions.write.overwrite_table",
+    "dqx_checks": [
+        {
+            "name": "rescued_data_empty",
+            "check": {
+                "function": "is_null",
+                "arguments": {
+                    "column": "_rescued_data"
+                }
+            }
+        }
+    ]
 }

--- a/layer_03_gold/systemsPopulated.json
+++ b/layer_03_gold/systemsPopulated.json
@@ -11,5 +11,16 @@
     "sample_type": "simple",
     "sample_id_col": "id",
     "sample_size": "1k",
-    "write_function": "functions.write.overwrite_table"
+    "write_function": "functions.write.overwrite_table",
+    "dqx_checks": [
+        {
+            "name": "rescued_data_empty",
+            "check": {
+                "function": "is_null",
+                "arguments": {
+                    "column": "_rescued_data"
+                }
+            }
+        }
+    ]
 }

--- a/layer_03_gold/systemsWithCoordinates.json
+++ b/layer_03_gold/systemsWithCoordinates.json
@@ -11,5 +11,16 @@
     "sample_type": "simple",
     "sample_id_col": "id",
     "sample_size": "1k",
-    "write_function": "functions.write.overwrite_table"
+    "write_function": "functions.write.overwrite_table",
+    "dqx_checks": [
+        {
+            "name": "rescued_data_empty",
+            "check": {
+                "function": "is_null",
+                "arguments": {
+                    "column": "_rescued_data"
+                }
+            }
+        }
+    ]
 }

--- a/layer_03_gold/systemsWithoutCoordinates.json
+++ b/layer_03_gold/systemsWithoutCoordinates.json
@@ -11,5 +11,16 @@
     "sample_type": "simple",
     "sample_id_col": "id",
     "sample_size": "1k",
-    "write_function": "functions.write.overwrite_table"
+    "write_function": "functions.write.overwrite_table",
+    "dqx_checks": [
+        {
+            "name": "rescued_data_empty",
+            "check": {
+                "function": "is_null",
+                "arguments": {
+                    "column": "_rescued_data"
+                }
+            }
+        }
+    ]
 }

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -142,6 +142,7 @@ class QualityTests(unittest.TestCase):
         self.assertIn('max_length', DummyRegistry.registered)
         self.assertIn('matches_regex_list', DummyRegistry.registered)
         self.assertIn('pattern_match', DummyRegistry.registered)
+        self.assertIn('is_null', DummyRegistry.registered)
         self.assertIn('is_nonzero', DummyRegistry.registered)
         self.assertIn('starts_with_prefixes', DummyRegistry.registered)
     def test_count_records_batch(self):


### PR DESCRIPTION
## Summary
- add `is_null` row-level DQX check
- register `is_null` in quality utilities
- document the new check
- add rescued_data_empty DQX rule to all JSON settings
- test registration for the new check

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ea26de25c83299b22e9abf4f05a17