### PR TITLE
Add dedicated history notebook

### DIFF
--- a/03_ingest.ipynb
+++ b/03_ingest.ipynb
@@ -1,125 +1,112 @@
 {
- "cells": [
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
-     "inputWidgets": {},
-     "nuid": "7862117b-bb6b-49b2-b7e3-33e9ebc942f2",
-     "showTitle": false,
-     "tableResultSettingsMap": {},
-     "title": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "%pip install databricks-labs-dqx==0.6.0\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
-     "inputWidgets": {},
-     "nuid": "c024346b-7af1-4838-9625-3d9006333016",
-     "showTitle": false,
-     "tableResultSettingsMap": {},
-     "title": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "import json\n",
-     "from pathlib import Path\n",
-  "from functions.utility import get_function, create_bad_records_table, apply_job_type, schema_exists, print_settings\n",
-  "from functions.history import build_and_merge_file_history\n",
-     "from functions.quality import create_dqx_bad_records_table\n",
-     "import os\n",
-    "\n",
-    "# Variables\n",
-    "color                       = dbutils.widgets.get('color')\n",
-    "job_settings                = json.loads(dbutils.widgets.get('job_settings'))\n",
-    "table                       = job_settings['table']\n",
-    "settings                    = json.loads(next(Path().glob(f'./layer_*_{color}/{table}.json')).read_text())\n",
-    "settings                    = apply_job_type(settings)\n",
-    "dst_table_name              = settings['dst_table_name']\n",
-    "\n",
-    "# Print job and table settings\n",
-    "print_settings(job_settings, settings, color, table)\n",
-    "\n",
-    "# One function for pipeline\n",
-    "if 'pipeline_function' in settings:\n",
-    "    pipeline_function = get_function(settings['pipeline_function'])\n",
-    "    pipeline_function(settings, spark)\n",
-    "\n",
-    "# Individual functions for each step\n",
-    "elif all(k in settings for k in ['read_function', 'transform_function', 'write_function']):\n",
-    "    read_function = get_function(settings['read_function'])\n",
-    "    transform_function = get_function(settings['transform_function'])\n",
-    "    write_function = get_function(settings['write_function'])\n",
-    "\n",
-    "    df = read_function(settings, spark)\n",
-    "    df = transform_function(df, settings, spark)\n",
-    "    df = create_dqx_bad_records_table(df, settings, spark)\n",
-    "    write_function(df, settings, spark)\n",
-    "else:\n",
-    "    raise Exception(f'Could not find any ingest function name in settings.')\n",
-    "\n",
-    "# Create a bad records table if bad records files found\n",
-    "if color == 'bronze':\n",
-    "    create_bad_records_table(settings, spark)\n",
-    "\n",
-    "# Build history if history settings are provided (default is true for bronze only)\n",
-    "history = job_settings.get('history', {})\n",
-    "if str(history.get('build_history', 'false')).lower() == 'true':\n",
-    "    full_table_name = history.get('full_table_name', dst_table_name)\n",
-    "    history_schema = history.get('history_schema')\n",
-    "    catalog = full_table_name.split('.')[0]\n",
-    "    if history_schema is None:\n",
-    "        print('Skipping history build: no history_schema provided')\n",
-    "    elif schema_exists(catalog, history_schema, spark):\n",
-  "        build_and_merge_file_history(full_table_name, history_schema, spark)\n",
-    "    else:\n",
-    "        print(f'Skipping history build: schema {catalog}.{history_schema} not found')\n"
-   ]
-  }
- ],
- "metadata": {
-  "application/vnd.databricks.v1+notebook": {
-   "computePreferences": {
-    "hardware": {
-     "accelerator": null,
-     "gpuPoolId": null,
-     "memory": null
-    }
-   },
-   "dashboards": [],
-   "environmentMetadata": {
-    "base_environment": "",
-    "environment_version": "3"
-   },
-   "inputWidgetPreferences": null,
-   "language": "python",
-   "notebookMetadata": {
-    "pythonIndentUnit": 4
-   },
-   "notebookName": "03_ingest",
-   "widgets": {}
-  },
-  "language_info": {
-   "name": "python"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 0
+    "cells": [
+        {
+            "cell_type": "code",
+            "execution_count": 0,
+            "metadata": {
+                "application/vnd.databricks.v1+cell": {
+                    "cellMetadata": {
+                        "byteLimit": 2048000,
+                        "rowLimit": 10000
+                    },
+                    "inputWidgets": {},
+                    "nuid": "7862117b-bb6b-49b2-b7e3-33e9ebc942f2",
+                    "showTitle": false,
+                    "tableResultSettingsMap": {},
+                    "title": ""
+                }
+            },
+            "outputs": [],
+            "source": [
+                "%pip install databricks-labs-dqx==0.6.0\n"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 0,
+            "metadata": {
+                "application/vnd.databricks.v1+cell": {
+                    "cellMetadata": {
+                        "byteLimit": 2048000,
+                        "rowLimit": 10000
+                    },
+                    "inputWidgets": {},
+                    "nuid": "c024346b-7af1-4838-9625-3d9006333016",
+                    "showTitle": false,
+                    "tableResultSettingsMap": {},
+                    "title": ""
+                }
+            },
+            "outputs": [],
+            "source": [
+                "import json\n",
+                "from pathlib import Path\n",
+                "from functions.utility import get_function, create_bad_records_table, apply_job_type, schema_exists, print_settings\n",
+                "from functions.quality import create_dqx_bad_records_table\n",
+                "import os\n",
+                "\n",
+                "# Variables\n",
+                "color                       = dbutils.widgets.get('color')\n",
+                "job_settings                = json.loads(dbutils.widgets.get('job_settings'))\n",
+                "table                       = job_settings['table']\n",
+                "settings                    = json.loads(next(Path().glob(f'./layer_*_{color}/{table}.json')).read_text())\n",
+                "settings                    = apply_job_type(settings)\n",
+                "dst_table_name              = settings['dst_table_name']\n",
+                "\n",
+                "# Print job and table settings\n",
+                "print_settings(job_settings, settings, color, table)\n",
+                "\n",
+                "# One function for pipeline\n",
+                "if 'pipeline_function' in settings:\n",
+                "    pipeline_function = get_function(settings['pipeline_function'])\n",
+                "    pipeline_function(settings, spark)\n",
+                "\n",
+                "# Individual functions for each step\n",
+                "elif all(k in settings for k in ['read_function', 'transform_function', 'write_function']):\n",
+                "    read_function = get_function(settings['read_function'])\n",
+                "    transform_function = get_function(settings['transform_function'])\n",
+                "    write_function = get_function(settings['write_function'])\n",
+                "\n",
+                "    df = read_function(settings, spark)\n",
+                "    df = transform_function(df, settings, spark)\n",
+                "    df = create_dqx_bad_records_table(df, settings, spark)\n",
+                "    write_function(df, settings, spark)\n",
+                "else:\n",
+                "    raise Exception(f'Could not find any ingest function name in settings.')\n",
+                "\n",
+                "# Create a bad records table if bad records files found\n",
+                "if color == 'bronze':\n",
+                "    create_bad_records_table(settings, spark)\n",
+                "\n"
+            ]
+        }
+    ],
+    "metadata": {
+        "application/vnd.databricks.v1+notebook": {
+            "computePreferences": {
+                "hardware": {
+                    "accelerator": null,
+                    "gpuPoolId": null,
+                    "memory": null
+                }
+            },
+            "dashboards": [],
+            "environmentMetadata": {
+                "base_environment": "",
+                "environment_version": "3"
+            },
+            "inputWidgetPreferences": null,
+            "language": "python",
+            "notebookMetadata": {
+                "pythonIndentUnit": 4
+            },
+            "notebookName": "03_ingest",
+            "widgets": {}
+        },
+        "language_info": {
+            "name": "python"
+        }
+    },
+    "nbformat": 4,
+    "nbformat_minor": 0
 }

--- a/04_history.ipynb
+++ b/04_history.ipynb
@@ -1,0 +1,52 @@
+{
+    "cells": [
+        {
+            "cell_type": "code",
+            "metadata": {},
+            "source": [
+                "%pip install databricks-labs-dqx==0.6.0"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "metadata": {},
+            "source": [
+                "import json\n",
+                "from pathlib import Path\n",
+                "from functions.utility import apply_job_type, print_settings, schema_exists\n",
+                "from functions.history import build_and_merge_file_history\n",
+                "\n",
+                "color = dbutils.widgets.get('color')\n",
+                "job_settings = json.loads(dbutils.widgets.get('job_settings'))\n",
+                "table = job_settings['table']\n",
+                "settings = json.loads(next(Path().glob(f'./layer_*_{color}/{table}.json')).read_text())\n",
+                "settings = apply_job_type(settings)\n",
+                "dst_table_name = settings['dst_table_name']\n",
+                "\n",
+                "print_settings(job_settings, settings, color, table)\n",
+                "\n",
+                "history = job_settings.get('history', {})\n",
+                "if str(history.get('build_history', 'false')).lower() == 'true':\n",
+                "    full_table_name = history.get('full_table_name', dst_table_name)\n",
+                "    history_schema = history.get('history_schema')\n",
+                "    catalog = full_table_name.split('.')[0]\n",
+                "    if history_schema is None:\n",
+                "        print('Skipping history build: no history_schema provided')\n",
+                "    elif schema_exists(catalog, history_schema, spark):\n",
+                "        build_and_merge_file_history(full_table_name, history_schema, spark)\n",
+                "    else:\n",
+                "        print(f'Skipping history build: schema {catalog}.{history_schema} not found')\n"
+            ]
+        }
+    ],
+    "metadata": {
+        "application/vnd.databricks.v1+notebook": {
+            "environmentMetadata": {
+                "base_environment": "",
+                "environment_version": "3"
+            }
+        }
+    },
+    "nbformat": 4,
+    "nbformat_minor": 0
+}

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ For documentation, see [here](https://github.com/bryanlharris/Documentation).
 * [docs/job-definition.md](docs/job-definition.md) - Overview of the job-definition YAML.
 * [docs/job_settings.md](docs/job_settings.md) - Details about preparing configuration for each task.
 * [docs/custom.md](docs/custom.md) - Creating and using custom transforms.
+* [docs/history.md](docs/history.md) - Notebook for building file ingestion history.
 * [docs/functions/config.md](docs/functions/config.md) - Constants shared across notebooks.
 * [docs/functions/utility.md](docs/functions/utility.md) - Utility helper functions.
 * [docs/functions/read.md](docs/functions/read.md) - Functions that read data sources.

--- a/docs/history.md
+++ b/docs/history.md
@@ -1,0 +1,11 @@
+# History notebook
+
+`04_history.ipynb` builds the file ingestion history table for a single table.
+
+1. `color` identifies the layer being processed.
+2. `job_settings` supplies the table name and history options.
+3. Reads the settings JSON and prints the resolved configuration.
+4. Calls `build_and_merge_file_history` when the history schema exists.
+5. Skips execution if no history schema is configured or the schema can't be found.
+
+This notebook runs after bronze ingestion so history creation can happen in parallel with silver processing.

--- a/docs/ingest.md
+++ b/docs/ingest.md
@@ -13,4 +13,3 @@ During execution the notebook performs the following steps:
 - Invokes the pipeline function or the individual read/transform/write functions.
 - Creates a DQX bad records table when applicable.
 - Builds a bad records table for bronze jobs if bad record files exist.
-- Builds the file ingestion history table when `build_history` is enabled and the history schema is present. Column types are retained and versions that fail to load due to missing files are skipped.

--- a/docs/job-definition.md
+++ b/docs/job-definition.md
@@ -7,6 +7,7 @@ The job is named **edsm** and is triggered when new files arrive under `/Volumes
 - **downloader** – runs the `utilities/downloader` notebook to fetch the nightly dump.
 - **job_settings** – loads job configuration from the `00_job_settings` notebook and passes settings to downstream tasks.
 - **bronze_loop** – iterates over the `bronze` job settings, launching the `03_ingest` notebook for each table with the parameter `color` set to `bronze`.
+- **history_loop** – builds file ingestion history tables using the `04_history` notebook.
 - **silver_parallel_loop** – processes tables listed under `silver_parallel` in parallel using the `03_ingest` notebook with `color` set to `silver`.
 - **silver_sequential_loop** – runs the remaining silver tasks one at a time from `silver_sequential`.
 - **gold_loop** – executes the final gold layer jobs defined in `gold`.

--- a/job-definition.yaml
+++ b/job-definition.yaml
@@ -38,6 +38,22 @@ resources:
                 source: WORKSPACE
               min_retry_interval_millis: 900000
               disable_auto_optimization: true
+        - task_key: history_loop
+          depends_on:
+            - task_key: bronze_loop
+          for_each_task:
+            inputs: "{{tasks.job_settings.values.bronze}}"
+            concurrency: 8
+            task:
+              task_key: history
+              notebook_task:
+                notebook_path: /Workspace/Users/bryanlharris@me.com/edsm/04_history
+                base_parameters:
+                  job_settings: "{{input}}"
+                  color: bronze
+                source: WORKSPACE
+              min_retry_interval_millis: 900000
+              disable_auto_optimization: true
         - task_key: silver_parallel_loop
           depends_on:
             - task_key: bronze_loop


### PR DESCRIPTION
## Summary
- split history logic into new `04_history.ipynb`
- update `03_ingest.ipynb` to remove history handling
- document the new notebook
- reference it from README and job definition
- include a new `history_loop` task in `job-definition.yaml`
- set notebook `environment_version` to 3

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ea9b2fd7c832985868c07587c4e18