### PR TITLE
Remove rescues and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,7 @@ For documentation, see [here](https://github.com/bryanlharris/Documentation).
 * [docs/utilities/drop_history_tables.md](docs/utilities/drop_history_tables.md) - Notebook for removing history tables.
 * [docs/utilities/migrate_history_tables.md](docs/utilities/migrate_history_tables.md) - Convert and remove old history tables.
 * [docs/utilities/add_history_ingest_time.md](docs/utilities/add_history_ingest_time.md) - Notebook for adding `ingest_time` to history tables.
+
+Bronze streaming jobs no longer enable Auto Loader's rescued data column by
+default. Set `cloudFiles.rescuedDataColumn` in your job settings if bad record
+capture is desired.

--- a/docs/bronze.md
+++ b/docs/bronze.md
@@ -27,11 +27,11 @@ information are stored under `utility/<table>` while input files are loaded from
 metadata from `_metadata` into `source_metadata`.  If
 `add_derived_ingest_time` is enabled a `derived_ingest_time` field is extracted
 from the file path using `derived_ingest_time_regex`.  The transform also ensures
-that a `_rescued_data` column exists so malformed records can be captured.
+that a `_rescued_data` column exists.
 
-Bad records detected by Auto Loader are written to the path specified by
-`badRecordsPath`.  After each run the job attempts to create a table named
-`<dst_table_name>_bad_records` from those files for inspection.
+When Auto Loader is configured with a `badRecordsPath`, those files can be
+converted into a `<dst_table_name>_bad_records` table using
+`create_bad_records_table`.
 
 ## History tables
 

--- a/docs/ingest.md
+++ b/docs/ingest.md
@@ -12,4 +12,5 @@ During execution the notebook performs the following steps:
 - Prints the current job and table settings with `print_settings`.
 - Invokes the pipeline function or the individual read/transform/write functions.
 - Creates a DQX bad records table when applicable.
-- Builds a bad records table for bronze jobs if bad record files exist.
+- Builds a bad records table for bronze jobs when Auto Loader outputs
+  bad record files.

--- a/functions/utility.py
+++ b/functions/utility.py
@@ -107,7 +107,6 @@ def apply_job_type(settings):
                     "inferSchema": "false",
                     "cloudFiles.schemaLocation": f"{base_volume}/_schema/",
                     "badRecordsPath": f"{base_volume}/_badRecords/",
-                    "cloudFiles.rescuedDataColumn": "_rescued_data",
                 },
                 "writeStreamOptions": {
                     "mergeSchema": "false",


### PR DESCRIPTION
## Summary
- stop adding `cloudFiles.rescuedDataColumn` in `apply_job_type`
- document that bronze jobs no longer capture bad records automatically

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ec72570f08329b4473f7e25a2f382