### PR TITLE
Remove rescued data handling from bronze transform

### DIFF
--- a/docs/bronze.md
+++ b/docs/bronze.md
@@ -26,8 +26,7 @@ information are stored under `utility/<table>` while input files are loaded from
 `bronze_standard_transform` adds an `ingest_time` column and copies ingestion
 metadata from `_metadata` into `source_metadata`.  If
 `add_derived_ingest_time` is enabled a `derived_ingest_time` field is extracted
-from the file path using `derived_ingest_time_regex`.  The transform also ensures
-that a `_rescued_data` column exists so malformed records can be captured.
+from the file path using `derived_ingest_time_regex`.
 
 Bad records detected by Auto Loader are written to the path specified by
 `badRecordsPath`.  After each run the job attempts to create a table named

--- a/docs/functions/transform.md
+++ b/docs/functions/transform.md
@@ -3,7 +3,7 @@
 ## Main transforms
 
 ### `bronze_standard_transform`
-Apply default bronze logic such as cleaning column names, attaching file metadata and adding an `ingest_time` column. A `_rescued_data` field is created when it is missing.
+Apply default bronze logic such as cleaning column names, attaching file metadata and adding an `ingest_time` column.
 
 Parameters
 - **df**: input DataFrame
@@ -80,12 +80,6 @@ Attach a `source_metadata` struct column derived from `_metadata` with file path
 Parameters
 - **df**: input DataFrame
 - **settings**: may disable metadata capture with `use_metadata`
-
-### `add_rescued_data`
-Ensure a `_rescued_data` column exists so malformed records can be stored.
-
-Parameters
-- **df**: input DataFrame
 
 ### `add_row_hash_mod`
 Add a numeric modulus of a row hash for deterministic sampling.

--- a/tests/test_bronze_transform.py
+++ b/tests/test_bronze_transform.py
@@ -60,7 +60,7 @@ class DummyDF:
         return self
 
 class BronzeTransformTests(unittest.TestCase):
-    def test_skip_add_rescued_when_schema_contains_column(self):
+    def test_transform_does_not_call_add_rescued_data(self):
         df = DummyDF(['foo'])
         settings = {
             'file_schema': [
@@ -70,10 +70,9 @@ class BronzeTransformTests(unittest.TestCase):
             'use_metadata': 'true'
         }
         with mock.patch.object(transform, 'clean_column_names', new=lambda df_in: df_in), \
-             mock.patch.object(transform, 'add_source_metadata', new=lambda df_in, settings: df_in), \
-             mock.patch.object(transform, 'add_rescued_data', new=mock.Mock(side_effect=lambda df_in: df_in)) as add_mock:
+             mock.patch.object(transform, 'add_source_metadata', new=lambda df_in, settings: df_in):
             transform.bronze_standard_transform(df, settings, spark=None)
-            add_mock.assert_not_called()
+            self.assertNotIn('add_rescued_data', df.calls)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- stop bronze_standard_transform from adding `_rescued_data`
- drop the unused `add_rescued_data` helper
- update bronze transform test
- update docs to reflect the new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ec73814b88329af5ff9de493abc1a