### PR TITLE
Remove _rescued_data fields from bronze JSON configs

### DIFF
--- a/layer_01_bronze/bodies7days.json
+++ b/layer_01_bronze/bodies7days.json
@@ -629,12 +629,6 @@
                 "name": "volcanismType",
                 "nullable": true,
                 "type": "string"
-            },
-            {
-                "metadata": {},
-                "name": "_rescued_data",
-                "nullable": true,
-                "type": "string"
             }
         ],
         "type": "struct"

--- a/layer_01_bronze/codex.json
+++ b/layer_01_bronze/codex.json
@@ -53,12 +53,6 @@
                 "name": "type",
                 "nullable": true,
                 "type": "string"
-            },
-            {
-                "metadata": {},
-                "name": "_rescued_data",
-                "nullable": true,
-                "type": "string"
             }
         ],
         "type": "struct"

--- a/layer_01_bronze/powerPlay.json
+++ b/layer_01_bronze/powerPlay.json
@@ -93,12 +93,6 @@
                 "name": "state",
                 "nullable": true,
                 "type": "string"
-            },
-            {
-                "metadata": {},
-                "name": "_rescued_data",
-                "nullable": true,
-                "type": "string"
             }
         ],
         "type": "struct"

--- a/layer_01_bronze/stations.json
+++ b/layer_01_bronze/stations.json
@@ -309,12 +309,6 @@
                     ],
                     "type": "struct"
                 }
-            },
-            {
-                "metadata": {},
-                "name": "_rescued_data",
-                "nullable": true,
-                "type": "string"
             }
         ],
         "type": "struct"

--- a/layer_01_bronze/systemsPopulated.json
+++ b/layer_01_bronze/systemsPopulated.json
@@ -1079,12 +1079,6 @@
                     },
                     "type": "array"
                 }
-            },
-            {
-                "metadata": {},
-                "name": "_rescued_data",
-                "nullable": true,
-                "type": "string"
             }
         ],
         "type": "struct"

--- a/layer_01_bronze/systemsWithCoordinates.json
+++ b/layer_01_bronze/systemsWithCoordinates.json
@@ -64,12 +64,6 @@
                 "name": "name",
                 "nullable": true,
                 "type": "string"
-            },
-            {
-                "metadata": {},
-                "name": "_rescued_data",
-                "nullable": true,
-                "type": "string"
             }
         ],
         "type": "struct"

--- a/layer_01_bronze/systemsWithCoordinates7days.json
+++ b/layer_01_bronze/systemsWithCoordinates7days.json
@@ -63,12 +63,6 @@
                 "name": "name",
                 "nullable": true,
                 "type": "string"
-            },
-            {
-                "metadata": {},
-                "name": "_rescued_data",
-                "nullable": true,
-                "type": "string"
             }
         ],
         "type": "struct"

--- a/layer_01_bronze/systemsWithoutCoordinates.json
+++ b/layer_01_bronze/systemsWithoutCoordinates.json
@@ -69,12 +69,6 @@
                 "name": "name",
                 "nullable": true,
                 "type": "string"
-            },
-            {
-                "metadata": {},
-                "name": "_rescued_data",
-                "nullable": true,
-                "type": "string"
             }
         ],
         "type": "struct"


### PR DESCRIPTION
## Summary
- remove `_rescued_data` from all bronze layer config files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ec743e410832993c86aec203b8481