### PR TITLE
Add utility to drop rescued data columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,4 @@ For documentation, see [here](https://github.com/bryanlharris/Documentation).
 * [docs/utilities/drop_history_tables.md](docs/utilities/drop_history_tables.md) - Notebook for removing history tables.
 * [docs/utilities/migrate_history_tables.md](docs/utilities/migrate_history_tables.md) - Convert and remove old history tables.
 * [docs/utilities/add_history_ingest_time.md](docs/utilities/add_history_ingest_time.md) - Notebook for adding `ingest_time` to history tables.
+* [docs/utilities/drop_rescued_data.md](docs/utilities/drop_rescued_data.md) - Notebook for removing `_rescued_data` columns from all tables.

--- a/docs/utilities/drop_rescued_data.md
+++ b/docs/utilities/drop_rescued_data.md
@@ -1,0 +1,7 @@
+# Drop `_rescued_data` columns
+
+`utilities/drop_rescued_data.ipynb` removes the `_rescued_data` column from every table in the `edsm` catalog.
+
+- Defines `drop_rescued_data_columns(spark, catalog)` which lists all schemas and tables in the catalog.
+- Drops `_rescued_data` when present and logs the action.
+- The notebook calls the function for the `edsm` catalog as an example.

--- a/utilities/drop_rescued_data.ipynb
+++ b/utilities/drop_rescued_data.ipynb
@@ -1,0 +1,60 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "00000000-0000-0000-0000-000000000000",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def drop_rescued_data_columns(spark, catalog):\n",
+    "    schemas = [row.namespace for row in spark.sql(f'SHOW SCHEMAS IN {catalog}').collect()]\n",
+    "    for schema in schemas:\n",
+    "        tables = spark.sql(f'SHOW TABLES IN {catalog}.{schema}').filter('isTemporary = false')\n",
+    "        for row in tables.collect():\n",
+    "            name = row.tableName\n",
+    "            columns = spark.table(f'{catalog}.{schema}.{name}').columns\n",
+    "            if '_rescued_data' in columns:\n",
+    "                spark.sql(f'ALTER TABLE {catalog}.{schema}.{name} DROP COLUMN _rescued_data')\n",
+    "                print(f'Dropped _rescued_data from {catalog}.{schema}.{name}')\n",
+    "            else:\n",
+    "                print(f'Skipping {catalog}.{schema}.{name}: no _rescued_data')\n",
+    "\n",
+    "drop_rescued_data_columns(spark, 'edsm')"
+   ]
+  }
+ ],
+ "metadata": {
+  "application/vnd.databricks.v1+notebook": {
+   "computePreferences": null,
+   "dashboards": [],
+   "environmentMetadata": {
+    "base_environment": "",
+    "environment_version": "3"
+   },
+   "inputWidgetPreferences": null,
+   "language": "python",
+   "notebookMetadata": {
+    "pythonIndentUnit": 4
+   },
+   "notebookName": "drop_rescued_data",
+   "widgets": {}
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
## Summary
- add `drop_rescued_data.ipynb` to remove `_rescued_data` columns from every table
- document the new notebook
- link the documentation from the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ec75150908329b1924b20ca98acb1