### PR TITLE
Only run dqx during silver ingest

### DIFF
--- a/03_ingest.ipynb
+++ b/03_ingest.ipynb
@@ -1,112 +1,117 @@
 {
-    "cells": [
-        {
-            "cell_type": "code",
-            "execution_count": 0,
-            "metadata": {
-                "application/vnd.databricks.v1+cell": {
-                    "cellMetadata": {
-                        "byteLimit": 2048000,
-                        "rowLimit": 10000
-                    },
-                    "inputWidgets": {},
-                    "nuid": "7862117b-bb6b-49b2-b7e3-33e9ebc942f2",
-                    "showTitle": false,
-                    "tableResultSettingsMap": {},
-                    "title": ""
-                }
-            },
-            "outputs": [],
-            "source": [
-                "%pip install databricks-labs-dqx==0.6.0\n"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 0,
-            "metadata": {
-                "application/vnd.databricks.v1+cell": {
-                    "cellMetadata": {
-                        "byteLimit": 2048000,
-                        "rowLimit": 10000
-                    },
-                    "inputWidgets": {},
-                    "nuid": "c024346b-7af1-4838-9625-3d9006333016",
-                    "showTitle": false,
-                    "tableResultSettingsMap": {},
-                    "title": ""
-                }
-            },
-            "outputs": [],
-            "source": [
-                "import json\n",
-                "from pathlib import Path\n",
-                "from functions.utility import get_function, create_bad_records_table, apply_job_type, schema_exists, print_settings\n",
-                "from functions.quality import create_dqx_bad_records_table\n",
-                "import os\n",
-                "\n",
-                "# Variables\n",
-                "color                       = dbutils.widgets.get('color')\n",
-                "job_settings                = json.loads(dbutils.widgets.get('job_settings'))\n",
-                "table                       = job_settings['table']\n",
-                "settings                    = json.loads(next(Path().glob(f'./layer_*_{color}/{table}.json')).read_text())\n",
-                "settings                    = apply_job_type(settings)\n",
-                "dst_table_name              = settings['dst_table_name']\n",
-                "\n",
-                "# Print job and table settings\n",
-                "print_settings(job_settings, settings, color, table)\n",
-                "\n",
-                "# One function for pipeline\n",
-                "if 'pipeline_function' in settings:\n",
-                "    pipeline_function = get_function(settings['pipeline_function'])\n",
-                "    pipeline_function(settings, spark)\n",
-                "\n",
-                "# Individual functions for each step\n",
-                "elif all(k in settings for k in ['read_function', 'transform_function', 'write_function']):\n",
-                "    read_function = get_function(settings['read_function'])\n",
-                "    transform_function = get_function(settings['transform_function'])\n",
-                "    write_function = get_function(settings['write_function'])\n",
-                "\n",
-                "    df = read_function(settings, spark)\n",
-                "    df = transform_function(df, settings, spark)\n",
-                "    df = create_dqx_bad_records_table(df, settings, spark)\n",
-                "    write_function(df, settings, spark)\n",
-                "else:\n",
-                "    raise Exception(f'Could not find any ingest function name in settings.')\n",
-                "\n",
-                "# Create a bad records table if bad records files found\n",
-                "if color == 'bronze':\n",
-                "    create_bad_records_table(settings, spark)\n",
-                "\n"
-            ]
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": 0,
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "cellMetadata": {
+            "byteLimit": 2048000,
+            "rowLimit": 10000
+          },
+          "inputWidgets": {},
+          "nuid": "7862117b-bb6b-49b2-b7e3-33e9ebc942f2",
+          "showTitle": false,
+          "tableResultSettingsMap": {},
+          "title": ""
         }
-    ],
-    "metadata": {
-        "application/vnd.databricks.v1+notebook": {
-            "computePreferences": {
-                "hardware": {
-                    "accelerator": null,
-                    "gpuPoolId": null,
-                    "memory": null
-                }
-            },
-            "dashboards": [],
-            "environmentMetadata": {
-                "base_environment": "",
-                "environment_version": "3"
-            },
-            "inputWidgetPreferences": null,
-            "language": "python",
-            "notebookMetadata": {
-                "pythonIndentUnit": 4
-            },
-            "notebookName": "03_ingest",
-            "widgets": {}
-        },
-        "language_info": {
-            "name": "python"
-        }
+      },
+      "outputs": [],
+      "source": [
+        "import sys, subprocess\n",
+        "color = dbutils.widgets.get('color')\n",
+        "if color == 'silver':\n",
+        "    subprocess.run([sys.executable, '-m', 'pip', 'install', 'databricks-labs-dqx==0.6.0'], check=True)\n",
+        "    dbutils.library.restartPython()\n"
+      ]
     },
-    "nbformat": 4,
-    "nbformat_minor": 0
+    {
+      "cell_type": "code",
+      "execution_count": 0,
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "cellMetadata": {
+            "byteLimit": 2048000,
+            "rowLimit": 10000
+          },
+          "inputWidgets": {},
+          "nuid": "c024346b-7af1-4838-9625-3d9006333016",
+          "showTitle": false,
+          "tableResultSettingsMap": {},
+          "title": ""
+        }
+      },
+      "outputs": [],
+      "source": [
+        "import json\n",
+        "from pathlib import Path\n",
+        "from functions.utility import get_function, create_bad_records_table, apply_job_type, schema_exists, print_settings\n",
+        "from functions.quality import create_dqx_bad_records_table\n",
+        "import os\n",
+        "\n",
+        "# Variables\n",
+        "color                       = dbutils.widgets.get('color')\n",
+        "job_settings                = json.loads(dbutils.widgets.get('job_settings'))\n",
+        "table                       = job_settings['table']\n",
+        "settings                    = json.loads(next(Path().glob(f'./layer_*_{color}/{table}.json')).read_text())\n",
+        "settings                    = apply_job_type(settings)\n",
+        "dst_table_name              = settings['dst_table_name']\n",
+        "\n",
+        "# Print job and table settings\n",
+        "print_settings(job_settings, settings, color, table)\n",
+        "\n",
+        "# One function for pipeline\n",
+        "if 'pipeline_function' in settings:\n",
+        "    pipeline_function = get_function(settings['pipeline_function'])\n",
+        "    pipeline_function(settings, spark)\n",
+        "\n",
+        "# Individual functions for each step\n",
+        "elif all(k in settings for k in ['read_function', 'transform_function', 'write_function']):\n",
+        "    read_function = get_function(settings['read_function'])\n",
+        "    transform_function = get_function(settings['transform_function'])\n",
+        "    write_function = get_function(settings['write_function'])\n",
+        "\n",
+        "    df = read_function(settings, spark)\n",
+        "    df = transform_function(df, settings, spark)\n",
+        "    if color == 'silver':\n",
+        "        df = create_dqx_bad_records_table(df, settings, spark)\n",
+        "    write_function(df, settings, spark)\n",
+        "else:\n",
+        "    raise Exception(f'Could not find any ingest function name in settings.')\n",
+        "\n",
+        "# Create a bad records table if bad records files found\n",
+        "if color == 'bronze':\n",
+        "    create_bad_records_table(settings, spark)\n",
+        "\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "application/vnd.databricks.v1+notebook": {
+      "computePreferences": {
+        "hardware": {
+          "accelerator": null,
+          "gpuPoolId": null,
+          "memory": null
+        }
+      },
+      "dashboards": [],
+      "environmentMetadata": {
+        "base_environment": "",
+        "environment_version": "3"
+      },
+      "inputWidgetPreferences": null,
+      "language": "python",
+      "notebookMetadata": {
+        "pythonIndentUnit": 4
+      },
+      "notebookName": "03_ingest",
+      "widgets": {}
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }


### PR DESCRIPTION
## Summary
- install databricks-labs-dqx only for silver loads
- guard create_dqx_bad_records_table so it only runs when ingesting silver data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ec7f16a908329886a029028344641