### PR TITLE
Fix schema lookup in drop_rescued_data

### DIFF
--- a/utilities/drop_rescued_data.ipynb
+++ b/utilities/drop_rescued_data.ipynb
@@ -19,8 +19,9 @@
    "outputs": [],
    "source": [
     "def drop_rescued_data_columns(spark, catalog):\n",
+    "    spark.sql(f'use catalog {catalog}')\n",
     "    system_schemas = ['information_schema', 'sys']\n",
-    "    schemas = [row.namespace for row in spark.sql(f'SHOW SCHEMAS IN {catalog}').collect()]\n",
+    "    schemas = [row.databaseName for row in spark.sql(f'SHOW SCHEMAS IN {catalog}').collect()]\n",
     "    for schema in schemas:\n",
     "        if schema in system_schemas:\n",
     "            print(f'Skipping system schema {schema}')\n",


### PR DESCRIPTION
## Summary
- update drop_rescued_data to use `databaseName` instead of `namespace`
- issue USE CATALOG command before listing schemas and views

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ed603dfcc832995e2c384d5be1003