### PR TITLE
Use job defaults in checkpoint utility

### DIFF
--- a/docs/utilities/inspect_checkpoint_folder.md
+++ b/docs/utilities/inspect_checkpoint_folder.md
@@ -5,7 +5,8 @@ This notebook helps debug streaming jobs by printing the batch to version mappin
 ## `utilities/inspect_checkpoint_folder.ipynb`
 
 - Lists JSON configuration files from `layer_02_silver` and creates a dropdown widget of available tables.
-- Loads the settings for the chosen table and passes them to `functions.utility.inspect_checkpoint_folder`.
+- Loads the settings for the chosen table, applies defaults with `apply_job_type`, and passes them to `functions.utility.inspect_checkpoint_folder`.
+- The defaults include write stream options with the checkpoint folder when `simple_settings` is true.
 - The function reads each offset file in the Delta checkpoint folder and prints the silver batch ID alongside the corresponding bronze version.
 - Includes an example SQL cell that shows `describe history edsm.bronze.bodies7days`.
 

--- a/utilities/inspect_checkpoint_folder.ipynb
+++ b/utilities/inspect_checkpoint_folder.ipynb
@@ -76,13 +76,14 @@
     "import sys\n",
     "\n",
     "sys.path.append(f\"{os.getcwd()}/..\")\n",
-    "from functions.utility import inspect_checkpoint_folder\n",
+    "from functions.utility import inspect_checkpoint_folder, apply_job_type\n",
     "\n",
     "if table_name == \"None Selected\":\n",
     "    print(\"No table selected.\")\n",
     "else:\n",
     "    settings_path = table_map[table_name]\n",
     "    settings = json.loads(Path(settings_path).read_text())\n",
+    "    settings = apply_job_type(settings)\n",
     "    inspect_checkpoint_folder(settings, table_name, spark)"
    ]
   },


### PR DESCRIPTION
## Summary
- load job defaults when inspecting a checkpoint folder
- document how defaults are applied for checkpoint inspection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687edd4508248329a47a1f9125147560