### PR TITLE
Improve downloader sed processing

### DIFF
--- a/utilities/downloader.sh
+++ b/utilities/downloader.sh
@@ -22,7 +22,16 @@ download(){
                 filename=$(basename "$url" .gz)
                 wget -nv -O - "$url" \
                     | gunzip -c \
-                    | jq -c '.[]' \
+                    | tr -d '\000' \
+                    | sed \
+                        -e '1s/^\s*\[\s*//' \
+                        -e '$s/\s*\]\s*$//' \
+                        -e 's/}[[:space:]]*,[[:space:]]*{/}\n{/g' \
+                        -e 's/^\s*//' \
+                        -e 's/},\s*$/}/' \
+                        -e '/^\s*[\[\]]\s*$/d' \
+                        -e 's/[[:space:]]*$//' \
+                        -e '/^$/d' \
                     | tee "$root_save_dir/$filename" > "$tmp_save_dir/$filename"
             done
         )


### PR DESCRIPTION
## Summary
- revert jq requirement in downloader
- add robust sed pipeline for newline-delimited JSON output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f8f90a5b08329942fcd0c0e96aa66