### PR TITLE
Add bronze starting versions notebook

### DIFF
--- a/utilities/bronze_starting_versions.ipynb
+++ b/utilities/bronze_starting_versions.ipynb
@@ -1,0 +1,84 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8dc3b723",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "00000000-0000-0000-0000-000000000001",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from glob import glob\n",
+    "from pathlib import Path\n",
+    "import json\n",
+    "import html\n",
+    "\n",
+    "try:\n",
+    "    from dbruntime.display import displayHTML  # type: ignore\n",
+    "except Exception:\n",
+    "    try:\n",
+    "        from IPython.display import display as displayHTML  # type: ignore\n",
+    "    except Exception:\n",
+    "        displayHTML = print  # type: ignore\n",
+    "\n",
+    "paths = sorted(glob('../layer_01_bronze/*.json'))\n",
+    "for path in paths:\n",
+    "    settings = json.loads(Path(path).read_text())\n",
+    "    table_name = settings['dst_table_name']\n",
+    "    latest_version = (\n",
+    "        spark.sql(f\"DESCRIBE HISTORY {table_name}\")\n",
+    "        .selectExpr('max(version) as v')\n",
+    "        .collect()[0]['v']\n",
+    "    )\n",
+    "    json_id = table_name.replace('.', '-') + '-json'\n",
+    "    json_str = json.dumps({'readStreamOptions': {'startingVersion': latest_version}}, indent=4)\n",
+    "    escaped = html.escape(json_str)\n",
+    "    displayHTML(f\"\"\"\n",
+    "<h3>{table_name}</h3>\n",
+    "<button onclick=\"copyJson('{json_id}')\">Copy JSON to Clipboard</button>\n",
+    "<textarea id=\"{json_id}\" style=\"display:none;\">{escaped}</textarea>\n",
+    "<pre>{escaped}</pre>\n",
+    "<script>\n",
+    "function copyJson(id) {{\n",
+    "    var textArea = document.getElementById(id);\n",
+    "    textArea.style.display = 'block';\n",
+    "    textArea.select();\n",
+    "    document.execCommand('copy');\n",
+    "    textArea.style.display = 'none';\n",
+    "}}\n",
+    "</script>\n",
+    "\"\"\")\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "application/vnd.databricks.v1+notebook": {
+   "computePreferences": null,
+   "dashboards": [],
+   "environmentMetadata": {
+    "base_environment": "",
+    "environment_version": "3"
+   },
+   "inputWidgetPreferences": null,
+   "language": "python",
+   "notebookMetadata": {
+    "pythonIndentUnit": 4
+   },
+   "notebookName": "bronze_starting_versions",
+   "widgets": {}
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
## Summary
- add a utility notebook that prints starting versions for all bronze tables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f98f8b8848329b87837dfa2cecf0b