### PR TITLE
Add silver_sample_batch job type

### DIFF
--- a/docs/functions/config.md
+++ b/docs/functions/config.md
@@ -27,6 +27,8 @@ The provided job types are:
   transform and writes the stream without upserts.
 - **silver_scd2_batch** – batch reads and upserts using SCD2 semantics.
 - **silver_standard_batch** – batch reads and writes a snapshot table.
+- **silver_sample_batch** – batch reads a table, samples it with
+  ``sample_table`` and overwrites the destination table.
 - **gold_standard_batch** – batch reads silver data and writes a snapshot
   table.
 

--- a/functions/config.py
+++ b/functions/config.py
@@ -44,6 +44,11 @@ JOB_TYPE_MAP = {
         "transform_function": "functions.transform.silver_standard_transform",
         "write_function": "functions.write.write_upsert_snapshot",
     },
+    "silver_sample_batch": {
+        "read_function": "functions.read.read_table",
+        "transform_function": "functions.transform.sample_table",
+        "write_function": "functions.write.overwrite_table",
+    },
     "gold_standard_batch": {
         "read_function": "functions.read.read_table",
         "transform_function": "functions.transform.silver_standard_transform",

--- a/tests/test_apply_job_type.py
+++ b/tests/test_apply_job_type.py
@@ -1,0 +1,71 @@
+import sys
+import types
+import pathlib
+import importlib.util
+import unittest
+
+# Stub minimal pyspark modules so functions.utility can be imported
+pyspark = types.ModuleType('pyspark')
+sql = types.ModuleType('pyspark.sql')
+types_mod = types.ModuleType('pyspark.sql.types')
+func_mod = types.ModuleType('pyspark.sql.functions')
+types_mod.StructType = type('StructType', (), {})
+sql.types = types_mod
+sql.functions = func_mod
+pyspark.sql = sql
+sys.modules.setdefault('pyspark', pyspark)
+sys.modules.setdefault('pyspark.sql', sql)
+sys.modules.setdefault('pyspark.sql.types', types_mod)
+sys.modules.setdefault('pyspark.sql.functions', func_mod)
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+# Provide a minimal ``functions`` package to satisfy relative imports
+pkg_path = pathlib.Path(__file__).resolve().parents[1] / 'functions'
+functions_pkg = types.ModuleType('functions')
+functions_pkg.__path__ = [str(pkg_path)]
+sys.modules.setdefault('functions', functions_pkg)
+
+# Import utility module dynamically
+util_path = (
+    pathlib.Path(__file__).resolve().parents[1] / 'functions' / 'utility.py'
+)
+spec = importlib.util.spec_from_file_location('functions.utility', util_path)
+utility = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(utility)
+
+
+class ApplyJobTypeTests(unittest.TestCase):
+    def test_merges_silver_sample_batch_defaults(self):
+        settings = {
+            'job_type': 'silver_sample_batch',
+            'simple_settings': 'true',
+            'dst_table_name': 'cat.silver.tbl'
+        }
+        result = utility.apply_job_type(settings)
+        expected = {
+            'job_type': 'silver_sample_batch',
+            'simple_settings': 'true',
+            'dst_table_name': 'cat.silver.tbl',
+            'read_function': 'functions.read.read_table',
+            'transform_function': 'functions.transform.sample_table',
+            'write_function': 'functions.write.overwrite_table',
+            'build_history': 'false',
+            'ingest_time_column': 'ingest_time',
+        }
+        self.assertEqual(result, expected)
+
+    def test_user_values_override_defaults(self):
+        settings = {
+            'job_type': 'silver_sample_batch',
+            'simple_settings': 'true',
+            'dst_table_name': 'cat.silver.tbl',
+            'write_function': 'custom.write'
+        }
+        result = utility.apply_job_type(settings)
+        self.assertEqual(result['write_function'], 'custom.write')
+        self.assertEqual(result['transform_function'], 'functions.transform.sample_table')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- support a `silver_sample_batch` entry in `JOB_TYPE_MAP`
- document the new job type
- test that `apply_job_type` merges defaults for `silver_sample_batch`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f99b58b9c8329a747bf9441494651