### PR TITLE
Remove awaitTermination calls

### DIFF
--- a/functions/quality.py
+++ b/functions/quality.py
@@ -129,7 +129,6 @@ def count_records(
             .option("checkpointLocation", location)
             .trigger(availableNow=True)
             .start()
-            .awaitTermination()
         )
         count = spark.sql(f"SELECT COUNT(*) FROM {name}").collect()[0][0]
         spark.catalog.dropTempView(name)
@@ -177,7 +176,6 @@ def create_dqx_bad_records_table(df: Any, settings: dict, spark: Any) -> Any:
             .option("checkpointLocation", location)
             .trigger(availableNow=True)
             .table(f"{dst_table_name}_dqx_bad_records")
-            .awaitTermination()
         )
         shutil.rmtree(location, ignore_errors=True)
 

--- a/functions/write.py
+++ b/functions/write.py
@@ -27,7 +27,6 @@ def stream_write_table(df, settings, spark):
         .table(dst_table_name)
     )
 
-    query.awaitTermination()
     return query
 
 
@@ -45,7 +44,6 @@ def stream_upsert_table(df, settings, spark):
         .start()
     )
 
-    query.awaitTermination()
     return query
 
 

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -156,7 +156,7 @@ class SimpleMergeTests(unittest.TestCase):
 
 
 class StreamingWriteTests(unittest.TestCase):
-    def test_stream_write_table_awaits(self):
+    def test_stream_write_table_returns_query(self):
         df = DummyStreamingDF()
         spark = DummySpark()
         settings = {
@@ -164,9 +164,9 @@ class StreamingWriteTests(unittest.TestCase):
             'writeStreamOptions': {}
         }
         query = write.stream_write_table(df, settings, spark)
-        self.assertTrue(query.terminated)
+        self.assertFalse(query.terminated)
 
-    def test_stream_upsert_table_awaits(self):
+    def test_stream_upsert_table_returns_query(self):
         df = DummyStreamingDF()
         spark = DummySpark()
         settings = {
@@ -175,7 +175,7 @@ class StreamingWriteTests(unittest.TestCase):
             'upsert_function': 'foo'
         }
         query = write.stream_upsert_table(df, settings, spark)
-        self.assertTrue(query.terminated)
+        self.assertFalse(query.terminated)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- remove `awaitTermination` from streaming writes
- adjust unit tests for changed streaming behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fa012ec0483298725312ad82e7d1d