### PR TITLE
Fix asynchronous DQX stream table

### DIFF
--- a/functions/quality.py
+++ b/functions/quality.py
@@ -143,12 +143,13 @@ def create_dqx_bad_records_table(df: Any, settings: dict, spark: Any) -> Any:
             .saveAsTable(dst_bad_table)
         )
 
-        (
+        query = (
             bad_df.writeStream.format("delta")
             .option("checkpointLocation", location)
             .trigger(availableNow=True)
             .table(dst_bad_table)
         )
+        query.awaitTermination()
         shutil.rmtree(location, ignore_errors=True)
         n_bad = spark.table(dst_bad_table).count()
     else:


### PR DESCRIPTION
## Summary
- make `create_dqx_bad_records_table` wait for the streaming write to finish before checking results
- adjust unit tests for the new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688178d2f7388329bd744cb9e6c570df