### PR TITLE
Fix sampling _rescued_data

### DIFF
--- a/functions/transform.py
+++ b/functions/transform.py
@@ -298,6 +298,9 @@ def sample_table(df, settings, spark):
     sample_type = str(settings.get("sample_type", "random")).lower()
     fraction = float(settings.get("sample_fraction", 0.01))
 
+    if "_rescued_data" in df.columns:
+        df = df.drop("_rescued_data")
+
     if sample_type == "deterministic":
         modulus = int(settings.get("hash_modulus", 1000000))
         threshold = int(fraction * modulus)


### PR DESCRIPTION
## Summary
- drop `_rescued_data` in `sample_table`
- unit test for dropping `_rescued_data`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688205fdced48329acaf1a404dce1b1c