### PR TITLE
Add bronze history configs

### DIFF
--- a/layer_01_bronze_history/bodies7days.json
+++ b/layer_01_bronze_history/bodies7days.json
@@ -1,0 +1,6 @@
+{
+    "simple_settings": "true",
+    "job_type": "history_pipeline",
+    "full_table_name": "edsm.bronze.bodies7days",
+    "history_schema": "history"
+}

--- a/layer_01_bronze_history/codex.json
+++ b/layer_01_bronze_history/codex.json
@@ -1,0 +1,6 @@
+{
+    "simple_settings": "true",
+    "job_type": "history_pipeline",
+    "full_table_name": "edsm.bronze.codex",
+    "history_schema": "history"
+}

--- a/layer_01_bronze_history/examples/example.json
+++ b/layer_01_bronze_history/examples/example.json
@@ -1,0 +1,6 @@
+{
+    "simple_settings": "true",
+    "job_type": "history_pipeline",
+    "full_table_name": "edsm.bronze.example",
+    "history_schema": "history"
+}

--- a/layer_01_bronze_history/powerPlay.json
+++ b/layer_01_bronze_history/powerPlay.json
@@ -1,0 +1,6 @@
+{
+    "simple_settings": "true",
+    "job_type": "history_pipeline",
+    "full_table_name": "edsm.bronze.powerPlay",
+    "history_schema": "history"
+}

--- a/layer_01_bronze_history/stations.json
+++ b/layer_01_bronze_history/stations.json
@@ -1,0 +1,6 @@
+{
+    "simple_settings": "true",
+    "job_type": "history_pipeline",
+    "full_table_name": "edsm.bronze.stations",
+    "history_schema": "history"
+}

--- a/layer_01_bronze_history/systemsPopulated.json
+++ b/layer_01_bronze_history/systemsPopulated.json
@@ -1,0 +1,6 @@
+{
+    "simple_settings": "true",
+    "job_type": "history_pipeline",
+    "full_table_name": "edsm.bronze.systemsPopulated",
+    "history_schema": "history"
+}

--- a/layer_01_bronze_history/systemsWithCoordinates.json
+++ b/layer_01_bronze_history/systemsWithCoordinates.json
@@ -1,0 +1,6 @@
+{
+    "simple_settings": "true",
+    "job_type": "history_pipeline",
+    "full_table_name": "edsm.bronze.systemsWithCoordinates",
+    "history_schema": "history"
+}

--- a/layer_01_bronze_history/systemsWithCoordinates7days.json
+++ b/layer_01_bronze_history/systemsWithCoordinates7days.json
@@ -1,0 +1,6 @@
+{
+    "simple_settings": "true",
+    "job_type": "history_pipeline",
+    "full_table_name": "edsm.bronze.systemsWithCoordinates7days",
+    "history_schema": "history"
+}

--- a/layer_01_bronze_history/systemsWithoutCoordinates.json
+++ b/layer_01_bronze_history/systemsWithoutCoordinates.json
@@ -1,0 +1,6 @@
+{
+    "simple_settings": "true",
+    "job_type": "history_pipeline",
+    "full_table_name": "edsm.bronze.systemsWithoutCoordinates",
+    "history_schema": "history"
+}


### PR DESCRIPTION
## Summary
- create `layer_01_bronze_history` folder
- add history pipeline settings for each bronze table

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68825e3d4a408329afd79d241f47203f