### PR TITLE
Remove backfill and overwrite settings from bronze configs

### DIFF
--- a/layer_01_bronze/bodies7days.json
+++ b/layer_01_bronze/bodies7days.json
@@ -8,9 +8,7 @@
         "cloudFiles.format": "json",
         "encoding": "utf-8",
         "pathGlobFilter": "bodies7days.json",
-        "multiline": "false",
-        "cloudFiles.backfillInterval": "1 day",
-        "cloudFiles.allowOverwrites": "true"
+        "multiline": "false"
     },
     "file_schema": {
         "fields": [

--- a/layer_01_bronze/codex.json
+++ b/layer_01_bronze/codex.json
@@ -8,9 +8,7 @@
         "cloudFiles.format": "json",
         "encoding": "utf-8",
         "pathGlobFilter": "codex.json",
-        "multiline": "false",
-        "cloudFiles.backfillInterval": "1 day",
-        "cloudFiles.allowOverwrites": "true"
+        "multiline": "false"
     },
     "file_schema": {
         "fields": [

--- a/layer_01_bronze/examples/example.json
+++ b/layer_01_bronze/examples/example.json
@@ -3,8 +3,5 @@
     "job_type": "bronze_standard_streaming",
     "dst_table_name": "edsm.bronze.example",
     "dqx_checks": [],
-    "readStreamOptions": {
-        "cloudFiles.backfillInterval": "1 day",
-        "cloudFiles.allowOverwrites": "true"
-    }
+    "readStreamOptions": {}
 }

--- a/layer_01_bronze/powerPlay.json
+++ b/layer_01_bronze/powerPlay.json
@@ -8,9 +8,7 @@
         "cloudFiles.format": "json",
         "encoding": "utf-8",
         "pathGlobFilter": "powerPlay.json",
-        "multiline": "false",
-        "cloudFiles.backfillInterval": "1 day",
-        "cloudFiles.allowOverwrites": "true"
+        "multiline": "false"
     },
     "file_schema": {
         "fields": [

--- a/layer_01_bronze/stations.json
+++ b/layer_01_bronze/stations.json
@@ -8,9 +8,7 @@
         "cloudFiles.format": "json",
         "encoding": "utf-8",
         "pathGlobFilter": "stations.json",
-        "multiline": "false",
-        "cloudFiles.backfillInterval": "1 day",
-        "cloudFiles.allowOverwrites": "true"
+        "multiline": "false"
     },
     "file_schema": {
         "fields": [

--- a/layer_01_bronze/systemsPopulated.json
+++ b/layer_01_bronze/systemsPopulated.json
@@ -8,9 +8,7 @@
         "cloudFiles.format": "json",
         "encoding": "utf-8",
         "pathGlobFilter": "systemsPopulated.json",
-        "multiline": "false",
-        "cloudFiles.backfillInterval": "1 day",
-        "cloudFiles.allowOverwrites": "true"
+        "multiline": "false"
     },
     "file_schema": {
         "fields": [

--- a/layer_01_bronze/systemsWithCoordinates.json
+++ b/layer_01_bronze/systemsWithCoordinates.json
@@ -9,9 +9,7 @@
         "encoding": "utf-8",
         "cloudFiles.maxFilesPerTrigger": "1",
         "pathGlobFilter": "systemsWithCoordinates.json",
-        "multiline": "false",
-        "cloudFiles.backfillInterval": "1 day",
-        "cloudFiles.allowOverwrites": "true"
+        "multiline": "false"
     },
     "file_schema": {
         "fields": [

--- a/layer_01_bronze/systemsWithCoordinates7days.json
+++ b/layer_01_bronze/systemsWithCoordinates7days.json
@@ -8,9 +8,7 @@
         "cloudFiles.format": "json",
         "encoding": "utf-8",
         "pathGlobFilter": "systemsWithCoordinates7days.json",
-        "multiline": "false",
-        "cloudFiles.backfillInterval": "1 day",
-        "cloudFiles.allowOverwrites": "true"
+        "multiline": "false"
     },
     "file_schema": {
         "fields": [

--- a/layer_01_bronze/systemsWithoutCoordinates.json
+++ b/layer_01_bronze/systemsWithoutCoordinates.json
@@ -8,9 +8,7 @@
         "cloudFiles.format": "json",
         "encoding": "utf-8",
         "pathGlobFilter": "systemsWithoutCoordinates.json",
-        "multiline": "false",
-        "cloudFiles.backfillInterval": "1 day",
-        "cloudFiles.allowOverwrites": "true"
+        "multiline": "false"
     },
     "file_schema": {
         "fields": [


### PR DESCRIPTION
## Summary
- clean up bronze JSON configs by removing `cloudFiles.backfillInterval` and `cloudFiles.allowOverwrites`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68826a13f5d483298b56d6b0a17f4d3f