### PR TITLE
Add Databricks workspace uploader script

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,5 @@ For documentation, see [here](https://github.com/bryanlharris/Documentation).
 * [docs/utilities/add_history_ingest_time.md](docs/utilities/add_history_ingest_time.md) - Notebook for adding `ingest_time` to history tables.
 * [docs/utilities/drop_rescued_data.md](docs/utilities/drop_rescued_data.md) - Notebook for removing `_rescued_data` columns from all tables.
 * [docs/utilities/restore_table_version_dashboard.md](docs/utilities/restore_table_version_dashboard.md) - Databricks SQL dashboard for restoring table versions.
+* [docs/utilities/uploader.md](docs/utilities/uploader.md) - Script for uploading notebooks to the workspace.
 * [docs/delta-sharing.md](docs/delta-sharing.md) - Sharing tables over Delta Sharing.

--- a/docs/utilities/uploader.md
+++ b/docs/utilities/uploader.md
@@ -1,0 +1,10 @@
+# Workspace uploader utility
+
+This script uploads files in the current directory to a Databricks workspace.
+
+## `utilities/uploader.sh`
+
+- Accepts a Databricks CLI profile name and a destination workspace path.
+- Runs `databricks --profile <profile> workspace import_dir -o <current directory> <destination>`.
+- Overwrites existing notebooks in the workspace.
+

--- a/utilities/uploader.sh
+++ b/utilities/uploader.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+    echo "Usage: $0 <profile> <workspace-destination>" >&2
+    exit 1
+fi
+
+profile="$1"
+dest="$2"
+
+if ! command -v databricks > /dev/null 2>&1; then
+    echo "Error: databricks CLI not found" >&2
+    exit 1
+fi
+
+# Import current directory to the workspace, overwriting existing items
+
+databricks --profile "$profile" workspace import_dir -o "$(pwd)" "$dest"
+


### PR DESCRIPTION
## Summary
- add utility script `uploader.sh` for pushing notebooks to a Databricks workspace
- document the new script
- link the documentation from the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68826a86eb408329a71fa203211df50b