### PR TITLE
Exclude .git from uploader

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,5 +30,5 @@ For documentation, see [here](https://github.com/bryanlharris/Documentation).
 * [docs/utilities/add_history_ingest_time.md](docs/utilities/add_history_ingest_time.md) - Notebook for adding `ingest_time` to history tables.
 * [docs/utilities/drop_rescued_data.md](docs/utilities/drop_rescued_data.md) - Notebook for removing `_rescued_data` columns from all tables.
 * [docs/utilities/restore_table_version_dashboard.md](docs/utilities/restore_table_version_dashboard.md) - Databricks SQL dashboard for restoring table versions.
-* [docs/utilities/uploader.md](docs/utilities/uploader.md) - Script for uploading notebooks to the workspace.
+* [docs/utilities/uploader.md](docs/utilities/uploader.md) - Script for uploading notebooks to the workspace (excludes `.git`).
 * [docs/delta-sharing.md](docs/delta-sharing.md) - Sharing tables over Delta Sharing.

--- a/docs/utilities/uploader.md
+++ b/docs/utilities/uploader.md
@@ -5,6 +5,7 @@ This script uploads files in the current directory to a Databricks workspace.
 ## `utilities/uploader.sh`
 
 - Accepts a Databricks CLI profile name and a destination workspace path.
-- Runs `databricks --profile <profile> workspace import_dir -o <current directory> <destination>`.
+- Runs `databricks --profile <profile> workspace import-dir <current directory> <destination> --overwrite`.
 - Overwrites existing notebooks in the workspace.
+- Uses `rsync` to exclude the `.git` folder before uploading.
 

--- a/utilities/uploader.sh
+++ b/utilities/uploader.sh
@@ -15,6 +15,10 @@ if ! command -v databricks > /dev/null 2>&1; then
 fi
 
 # Import current directory to the workspace, overwriting existing items
+# Exclude the .git folder so repository metadata is not uploaded
 
-databricks --profile "$profile" workspace import_dir -o "$(pwd)" "$dest"
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+rsync -a --exclude='.git' ./ "$tmp_dir"/
+databricks --profile "$profile" workspace import-dir "$tmp_dir" "$dest" --overwrite
 


### PR DESCRIPTION
## Summary
- avoid uploading repo metadata by excluding `.git` in `uploader.sh`
- document exclusion in docs and README
- fix the import command syntax and overwrite flag

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6882709ca65083298f1778f21b1fef67