### PR TITLE
Fix pipeline job validation

### DIFF
--- a/docs/functions/sanity.md
+++ b/docs/functions/sanity.md
@@ -11,6 +11,9 @@ the bronze, silver, silver sample and gold layers.
 ## `validate_settings`
 
 Ensure each settings file contains the required keys for its layer.
+Jobs that define a `pipeline_function` skip these checks so custom
+pipelines such as the history job can omit the standard
+`read_function`, `transform_function` and `write_function` keys.
 Extra requirements are enforced for certain write functions. Raises an
 exception when any file fails validation. When settings are valid it also
 calls `validate_s3_roots` to warn about missing trailing slashes in the

--- a/functions/sanity.py
+++ b/functions/sanity.py
@@ -108,8 +108,11 @@ def validate_settings(dbutils):
         ("gold", gold_files),
     ]:
         for tbl, path in files.items():
-            settings=json.loads(open(path).read())
+            settings = json.loads(open(path).read())
             settings = apply_job_type(settings)
+            # Skip validation when a pipeline function is used
+            if "pipeline_function" in settings:
+                continue
             for k in required_keys[layer]:
                 if k not in settings:
                     errs.append(f"{path} missing {k}")
@@ -117,7 +120,9 @@ def validate_settings(dbutils):
             if write_fn in write_key_requirements:
                 for req_key in write_key_requirements[write_fn]:
                     if req_key not in settings:
-                        errs.append(f"{path} missing {req_key} for write_function {write_fn}")
+                        errs.append(
+                            f"{path} missing {req_key} for write_function {write_fn}"
+                        )
 
     if errs:
         raise RuntimeError("Sanity check failed: "+", ".join(errs))


### PR DESCRIPTION
## Summary
- skip required key validation when a pipeline_function is defined
- document pipeline job behaviour in sanity docs
- test pipeline_function skip

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884b577d5a883298afe75679fa8d5ba