### PR TITLE
Document silver dependencies and loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ For documentation, see [here](https://github.com/bryanlharris/Documentation).
 
 * [docs/bronze.md](docs/bronze.md) - Overview of the bronze layer.
 * [docs/silver.md](docs/silver.md) - Overview of how silver data is ingested, transformed and written.
+* [docs/table_dependencies.md](docs/table_dependencies.md) - Silver table dependencies and execution order.
 * [docs/ingest.md](docs/ingest.md) - Explanation of the ingest notebook.
 * [docs/sampling.md](docs/sampling.md) - Information on generating sample data.
 * [docs/job-definition.md](docs/job-definition.md) - Overview of the job-definition YAML.

--- a/docs/job-definition.md
+++ b/docs/job-definition.md
@@ -8,8 +8,9 @@ The job is named **edsm** and is triggered when new files arrive under `/Volumes
 - **job_settings** – loads job configuration from the `00_job_settings` notebook and passes settings to downstream tasks.
 - **bronze_loop** – iterates over the `bronze` job settings, launching the `03_ingest` notebook for each table with the parameter `color` set to `bronze`.
 - **history_loop** – builds file ingestion history tables using the `04_history` notebook.
-- **silver_loop** – processes tables listed under `silver` using the `03_ingest` notebook with `color` set to `silver`.
-- **silver_samples_loop** – executes any sampling jobs defined under `silver_samples` after the silver loop completes.
+- **silver_parallel_loop** – runs silver tables without dependencies in parallel using the `03_ingest` notebook with `color` set to `silver`.
+- **silver_sequential_loop** – processes silver tables that declare a `requires` field in order after the parallel loop finishes.
+- **silver_samples_loop** – executes any sampling jobs defined under `silver_samples` after both silver loops complete.
 - **gold_loop** – executes the final gold layer jobs defined in `gold`.
 
 Each task references notebooks in the Databricks workspace and has retry settings disabled for auto optimization.

--- a/docs/job_settings.md
+++ b/docs/job_settings.md
@@ -2,17 +2,40 @@
 
 `00_job_settings.ipynb` prepares configuration values for each task in the job. It scans all JSON files under `layer_*_<color>` and groups them by color.
 
-For bronze and gold tables every file is loaded and the following data is written to `job_settings[color]`:
+For bronze and gold tables every file is loaded and the following data is
+written to `job_settings[color]`:
 
 - `table` – the table name derived from the file name
-- `history` – dictionary with `build_history`, `history_schema` and `full_table_name`
+- `history` – dictionary with `build_history`, `history_schema` and
+  `full_table_name`
 
-Silver files are loaded the same way and added to `job_settings['silver']`.
+Silver files are split into two lists based on the optional `requires` field:
+
+- Tables without dependencies are stored under `job_settings['silver_parallel']`
+  and run concurrently by the `silver_parallel_loop`.
+- Tables declaring upstream tables in a `requires` list are stored under
+  `job_settings['silver_sequential']`.  This list is topologically sorted so
+  each dependency runs before its dependents when executed by the
+  `silver_sequential_loop`.
 
 Files in `layer_*_silver_samples` configure sampling jobs. Each file is loaded
 like the bronze and gold layers and added to `job_settings['silver_samples']`.
-`job-definition.yaml` should contain a `silver_samples_loop` that iterates over
-this list.
+`job-definition.yaml` should contain `silver_parallel_loop`,
+`silver_sequential_loop` and `silver_samples_loop` tasks that iterate over these
+lists.
+
+### Example
+
+```
+layer_02_silver/systems.json      -> {}
+layer_02_silver/stations.json     -> {"requires": ["systems"]}
+
+job_settings['silver_parallel']   = [{'table': 'systems'}]
+job_settings['silver_sequential'] = [{'table': 'stations', 'requires': ['systems']}]
+```
+
+The job first processes `systems` in the parallel loop. Once all parallel tasks
+finish, the sequential loop runs `stations` because it depends on `systems`.
 
 Each section of `job_settings` is stored in a Databricks task value so downstream notebooks can access the configuration.
 Finally the notebook runs several sanity checks:

--- a/docs/silver.md
+++ b/docs/silver.md
@@ -2,6 +2,8 @@
 
 Silver tables refine the cleaned bronze data into curated Delta tables. Each configuration file under `layer_02_silver` describes one table and usually sets `simple_settings` to `true` with an appropriate `job_type`.
 
+See [table_dependencies](table_dependencies.md) for how silver configs declare dependencies and how the parallel and sequential loops process them.
+
 ## Standard job types
 
 These are the possible values for `job_type` when `simple_settings` is set to `true` in the json file.

--- a/docs/table_dependencies.md
+++ b/docs/table_dependencies.md
@@ -1,0 +1,13 @@
+# Table dependencies
+
+Silver tables can declare dependencies on other silver tables using an optional `requires` field. During ingestion, tables without dependencies run in a `silver_parallel_loop` while dependent tables are processed later by a `silver_sequential_loop` that honors the `requires` relationships.
+
+## Example
+
+```
+layer_02_silver/systems.json      -> {}
+layer_02_silver/stations.json     -> {"requires": ["systems"]}
+
+silver_parallel_loop:  systems
+silver_sequential_loop: stations
+```


### PR DESCRIPTION
## Summary
- Move silver table dependency description into new `docs/table_dependencies.md`
- Link the new dependency guide from the README and silver layer docs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689666013e188329931497d0b2ed04eb