### PR TITLE
Normalize table names for dependency tracking

### DIFF
--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -36,9 +36,18 @@ def test_cycle_detection():
 
 def test_build_dependency_graph():
     settings = [
-        {"dst_table_name": "a"},
-        {"src_table_name": "a", "dst_table_name": "b"},
+        {"dst_table_name": "A"},
+        {"src_table_name": "a", "dst_table_name": "B"},
     ]
     items = build_dependency_graph(settings)
     result = sort_by_dependency(items)
     assert [i["table"] for i in result] == ["a", "b"]
+
+
+def test_sort_by_dependency_case_insensitive():
+    items = [
+        {"table": "TableB", "requires": ["TableA"]},
+        {"table": "tablea"},
+    ]
+    result = sort_by_dependency(items)
+    assert [i["table"] for i in result] == ["tablea", "tableb"]


### PR DESCRIPTION
## Summary
- Normalize table names to lowercase when building dependency graphs and sorting
- Use lowercase keys when initializing empty tables for consistent lookups
- Add tests covering case-insensitive dependency resolution

## Testing
- `pytest tests/test_dependencies.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689a6ee999288329aed2d4c12b8966c6