### PR TITLE
Use row count for simple sampling

### DIFF
--- a/docs/sampling.md
+++ b/docs/sampling.md
@@ -13,12 +13,12 @@ If omitted, random sampling is used.
   ensures the same subset is returned each time when the input data is
   unchanged.
 * `simple` – rows are selected by hashing a specific ID column and applying
-  ``pmod(hash(id), N) = 0``. ``N`` is calculated as ``approx_count_distinct(*) /
-  sample_size`` using the table referenced by ``src_table_name``. The ``settings``
-  dictionary must include ``sample_id_col`` naming the column to hash and
-  ``sample_size`` specifying how many rows to keep. The ``sample_size`` value
-  supports SI notation such as ``1k`` or ``5m``. Only rows where the ID is not
-  null are considered. ``sample_fraction`` is ignored for this mode. When the
+  ``pmod(hash(id), N) = 0``. ``N`` is calculated as ``count(*) /
+  sample_size`` using the row count of the table referenced by ``src_table_name``.
+  The ``settings`` dictionary must include ``sample_id_col`` naming the column to
+  hash and ``sample_size`` specifying how many rows to keep. The ``sample_size``
+  value supports SI notation such as ``1k`` or ``5m``. Only rows where the ID is
+  not null are considered. ``sample_fraction`` is ignored for this mode. When the
   table named by ``src_table_name`` does not exist ``sample_table`` returns the
   input unchanged so ``initialize_empty_tables`` can run without errors.
 

--- a/functions/transform.py
+++ b/functions/transform.py
@@ -315,13 +315,12 @@ def sample_table(df, settings, spark):
     if sample_type == "simple":
         id_col = settings["sample_id_col"]
         sample_size = parse_si(settings["sample_size"])
-        if not spark.catalog.tableExists(settings["src_table_name"]):
+        src_table_name = settings["src_table_name"]
+        if not spark.catalog.tableExists(src_table_name):
             return df
 
         total = (
-            spark.sql(
-                f"SELECT approx_count_distinct({id_col}) AS total FROM {settings['src_table_name']}"
-            )
+            spark.sql(f"SELECT count(*) AS total FROM {src_table_name}")
             .collect()[0][0]
         )
         modulus = max(int(total / sample_size), 1)

--- a/tests/test_sample_table.py
+++ b/tests/test_sample_table.py
@@ -6,6 +6,9 @@ import unittest
 
 func_mod = sys.modules['pyspark.sql.functions']
 types_mod = sys.modules['pyspark.sql.types']
+window_mod = types.ModuleType('pyspark.sql.window')
+setattr(window_mod, 'Window', type('Window', (), {}))
+sys.modules['pyspark.sql.window'] = window_mod
 
 for name in [
     'StructType', 'StructField', 'StringType', 'LongType',
@@ -33,7 +36,7 @@ def dummy(*args, **kwargs):
 for name in [
     'concat','regexp_extract','date_format','current_timestamp','when','col',
     'to_timestamp','to_date','regexp_replace','sha2','lit','trim','struct',
-    'to_json','expr','transform','array','rand','conv','substring','hash','pmod'
+    'to_json','expr','transform','array','rand','conv','substring','hash','pmod','row_number'
 ]:
     func_mod.__dict__.setdefault(name, dummy)
 
@@ -86,7 +89,7 @@ class SimpleSampleTests(unittest.TestCase):
         self.assertEqual(captured.get('modulus'), 5)
         self.assertEqual(
             spark.query,
-            'SELECT approx_count_distinct(id) AS total FROM tbl'
+            'SELECT count(*) AS total FROM tbl'
         )
 
     def test_returns_input_when_table_missing(self):


### PR DESCRIPTION
## Summary
- compute simple sampling modulus using table row count instead of approx_count_distinct
- update unit tests to expect COUNT(*) query and mock needed Spark helpers
- document that simple sampling derives modulus from row count

## Testing
- `pytest tests/test_sample_table.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689b8d12121483298bc2d6488e2aa07f