### PR TITLE
Document deterministic sampling with SI notation

### DIFF
--- a/docs/sampling.md
+++ b/docs/sampling.md
@@ -71,8 +71,8 @@ modulus of one million.
 ```python
 settings = {
     "sample_type": "deterministic",
-    "sample_size": "10k",
-    "hash_modulus": "1M",
+    "sample_size": "10k",  # ten thousand rows
+    "hash_modulus": "1M",  # modulus of one million
 }
 
 sampled_df = sample_table(df, settings, spark)

--- a/layer_02_silver_samples/examples/example_100k.json
+++ b/layer_02_silver_samples/examples/example_100k.json
@@ -3,8 +3,8 @@
     "job_type": "silver_sample_batch",
     "src_table_name": "edsm.silver.example",
     "dst_table_name": "edsm.silver_samples.example_100k",
-    "sample_type": "simple",
-    "sample_id_col": "id",
+    "sample_type": "deterministic",
     "sample_size": "100k",
+    "hash_modulus": "1M",
     "dqx_checks": []
 }


### PR DESCRIPTION
## Summary
- clarify deterministic sampling docs with sample_size and hash_modulus as SI strings
- show deterministic JSON example using sample_size and hash_modulus

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fddc249e48329848779b0fc13ee81