### PR TITLE
Disallow SI sample_fraction and refine sampling tests

### DIFF
--- a/tests/test_sample_table.py
+++ b/tests/test_sample_table.py
@@ -154,16 +154,28 @@ class DeterministicSampleTests(unittest.TestCase):
         self.assertEqual(captured.get('threshold'), 2)
         self.assertIn('row_hash_mod', df.dropped)
 
+    def test_fraction_si_notation_raises(self):
+        spark = DummySpark()
+        settings = {
+            'sample_type': 'deterministic',
+            'sample_fraction': '500k',
+            'hash_modulus': '1M',
+        }
+        df = DummyDF(columns=['row_hash'])
+        with self.assertRaises(ValueError):
+            transform.sample_table(df, settings, spark=spark)
+
     def test_uses_sample_size(self):
         spark = DummySpark()
         settings = {
             'sample_type': 'deterministic',
-            'sample_size': '3',
-            'hash_modulus': '10',
+            'sample_size': '10k',
+            'hash_modulus': '1M',
         }
         df = DummyDF(columns=['row_hash'])
         transform.sample_table(df, settings, spark=spark)
-        self.assertEqual(captured.get('threshold'), 3)
+        self.assertEqual(captured.get('modulus'), 1000000)
+        self.assertEqual(captured.get('threshold'), 10000)
 
     def test_requires_parameter(self):
         spark = DummySpark()
@@ -180,8 +192,8 @@ class DeterministicSampleTests(unittest.TestCase):
         settings = {
             'sample_type': 'deterministic',
             'sample_fraction': 0.1,
-            'sample_size': '5',
-            'hash_modulus': '10',
+            'sample_size': '10k',
+            'hash_modulus': '1M',
         }
         df = DummyDF(columns=['row_hash'])
         with self.assertRaises(ValueError):


### PR DESCRIPTION
## Summary
- remove SI notation parsing for `sample_fraction`
- ensure SI-based `sample_fraction` raises an error
- keep sample-size test verifying threshold under SI notation

## Testing
- `pytest tests/test_sample_table.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fdd9a79688329b849db8e7653046b